### PR TITLE
allows to manually specify qgis_process location

### DIFF
--- a/R/qgis-process.R
+++ b/R/qgis-process.R
@@ -53,14 +53,17 @@ assert_qgis <- function(action = stop) {
 
 #' @rdname qgis_run
 #' @export
-qgis_configure <- function(quiet = FALSE) {
+qgis_configure <- function(quiet = FALSE, qgisprocess_path = NULL) {
   tryCatch({
-    qgisprocess_cache$path <- NULL
+    qgisprocess_cache$path <- qgisprocess_path
     qgisprocess_cache$version <- NULL
     qgisprocess_cache$algorithms <- NULL
     qgisprocess_cache$help_text <- new.env(parent = emptyenv())
 
-    qgis_path(query = TRUE, quiet = quiet)
+    if (is.null(qgisprocess_cache$path)) {
+      qgis_path(query = TRUE, quiet = quiet)
+    }
+
     qgis_version(query = TRUE, quiet = quiet)
     qgis_algorithms(query = TRUE, quiet = quiet)
   }, error = function(e) {


### PR DESCRIPTION
It is really hard to detect QGIS installation on Windows especially if OSGEO4W installer is used. This allows the path to the exe file to be manually passed to `qgis_configure()`. If the argument `qgisprocess_path` is not set then the function should work as previously.

