### PR TITLE
minor improvements to passing data to QGIS

### DIFF
--- a/R/qgis-arguments.R
+++ b/R/qgis-arguments.R
@@ -46,7 +46,7 @@ as_qgis_argument.sf <- function(x, qgis_type) {
     stop(glue::glue("Can't use 'sf' objects for QGIS arguments with type '{ qgis_type }'"), call. = FALSE)
   }
 
-  path <- tempfile(fileext = ".shp")
+  path <- tempfile(fileext = ".gpkg")
   sf::write_sf(x, path)
   structure(path, class = "qgis_tempfile")
 }
@@ -56,6 +56,17 @@ as_qgis_argument.sf <- function(x, qgis_type) {
 as_qgis_argument.RasterLayer <- function(x, qgis_type) {
   if (qgis_type != "raster") {
     stop(glue::glue("Can't use 'RasterLayer' objects for QGIS arguments with type '{ qgis_type }'"), call. = FALSE)
+  }
+
+  if (x@file@name != ""){
+    file_ext <- stringr::str_match(a,
+                                   ".*\\.([a-zA-Z]+)$")[2]
+
+    file_ext <- stringr::str_to_lower(file_ext)
+
+    if (file_ext %in% c("grd", "asc", "sdat", "rst", "nc", "tif", "tiff", "gtiff", "envi", "bil", "img")){
+      return(x@file@name)
+    }
   }
 
   path <- tempfile(fileext = ".tif")

--- a/tests/testthat/test-qgis-arguments.R
+++ b/tests/testthat/test-qgis-arguments.R
@@ -11,7 +11,7 @@ test_that("sf argument coercers work", {
   sf_obj <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))
   expect_error(as_qgis_argument(sf_obj, "integer"), "Can't use 'sf' objects")
 
-  tmp_file <- expect_match(as_qgis_argument(sf_obj, "source"), "\\.shp$")
+  tmp_file <- expect_match(as_qgis_argument(sf_obj, "source"), "\\.gpkg$")
   expect_is(tmp_file, "qgis_tempfile")
   unlink(tmp_file)
 })


### PR DESCRIPTION
It seems more reasonable to use geopackage to pass data from R memory to QGIS processing. Shapefile has some limitations that may cause errors [http://switchfromshapefile.org/](http://switchfromshapefile.org/). Especially the 10 characters limit on the column names can be problematic.


For rasters, if the object actually stores a filename and it's of known type, the filename can be passed directly. This avoids unnecessary storage of potentially large data. I tested it and if the data are manually edited then the raster object does no longer provide the filename. It thus seems safe to do this.

This example.
```
f <- system.file("external/test.grd", package="raster")
f
r <- raster(f)
r@file@name
```
Here the filename exists.

```
values(r) <- 1:ncell(r) 
r@file@name
```
After the edit, the filename does not exist.
