### PR TITLE
make multiple input arguments work

### DIFF
--- a/R/qgis-algorithm.R
+++ b/R/qgis-algorithm.R
@@ -54,9 +54,10 @@ qgis_run_algorithm <- function(algorithm, ..., PROJECT_PATH = NULL, ELIPSOID = N
   arg_meta <- arg_meta[rep(ro, times = r), ]
   args = rlang::set_names(c(arg_meta$name, "PROJECT_PATH", "ELIPSOID"))
   # we need to write it like this due to duplicated names
-  args[names(args) %in% names(dots)] <- dots
-  args[!names(args) %in% names(dots)] <-
-    lapply(args[!names(args) %in% names(dots)], function(x) qgis_default_value())
+  ind = names(args) %in% names(dots)
+  args[ind] <- dots[names(args)[ind]]
+  args[!ind] <-
+    lapply(args[!ind], function(x) qgis_default_value())
   args["PROJECT_PATH"] <- list(PROJECT_PATH)
   args["ELIPSOID"] <- list(ELIPSOID)
 

--- a/tests/testthat/test-qgis-algorithm.R
+++ b/tests/testthat/test-qgis-algorithm.R
@@ -35,6 +35,7 @@ test_that("qgis_run_algorithm() ignores unknown inputs", {
 test_that("qgis_run_algorithm accepts multipleinput arguments", {
   skip_if_not(has_qgis())
   skip_if_not_installed("sf")
+  skip("Requires recent QGIS")
 
   v_1 = sf::read_sf(
     system.file("longlake/longlake.gpkg", package = "qgisprocess"))

--- a/tests/testthat/test-qgis-algorithm.R
+++ b/tests/testthat/test-qgis-algorithm.R
@@ -34,17 +34,19 @@ test_that("qgis_run_algorithm() ignores unknown inputs", {
 
 test_that("qgis_run_algorithm accepts multipleinput arguments", {
   skip_if_not(has_qgis())
+  skip_if_not_installed("sf")
+
   v_1 = sf::read_sf(
     system.file("longlake/longlake.gpkg", package = "qgisprocess"))
   v_2 = v_3 = v_1
   v_2$geom = v_2$geom + 1000
-  st_crs(v_2) = st_crs(v_1)
+  sf::st_crs(v_2) = sf::st_crs(v_1)
   v_3$geom = v_3$geom - 1000
-  st_crs(v_3) = st_crs(v_1)
+  sf::st_crs(v_3) = sf::st_crs(v_1)
   out = qgis_run_algorithm("native:mergevectorlayers",
                            LAYERS = v_1, LAYERS = v_2, LAYERS = v_3,
                            .quiet = TRUE)
-  tmp = read_sf(qgis_output(out, "OUTPUT"))
+  tmp = sf::read_sf(qgis_output(out, "OUTPUT"))
   expect_equal(nrow(tmp), 3)
 })
 

--- a/tests/testthat/test-qgis-algorithm.R
+++ b/tests/testthat/test-qgis-algorithm.R
@@ -32,6 +32,22 @@ test_that("qgis_run_algorithm() ignores unknown inputs", {
   )
 })
 
+test_that("qgis_run_algorithm accepts multipleinput arguments", {
+  skip_if_not(has_qgis())
+  v_1 = sf::read_sf(
+    system.file("longlake/longlake.gpkg", package = "qgisprocess"))
+  v_2 = v_3 = v_1
+  v_2$geom = v_2$geom + 1000
+  st_crs(v_2) = st_crs(v_1)
+  v_3$geom = v_3$geom - 1000
+  st_crs(v_3) = st_crs(v_1)
+  out = qgis_run_algorithm("native:mergevectorlayers",
+                           LAYERS = v_1, LAYERS = v_2, LAYERS = v_3,
+                           .quiet = TRUE)
+  tmp = read_sf(qgis_output(out, "OUTPUT"))
+  expect_equal(nrow(tmp), 3)
+})
+
 test_that("qgis_has_algorithm() works", {
   skip_if_not(has_qgis())
   expect_true(qgis_has_algorithm("native:filedownloader"))


### PR DESCRIPTION
Thanks to qgis/QGIS#40287 multiple input arguments are now accepted by `qgisprocess`. This PR slighly adjusts `qgis_run_algorithm()` to make them also work from within R. I have already successfully tested this using the QGIS nightly build (3.17.0-Master). However, so far this only works if only one of the arguments is of type multipleinput. I am not sure if there are QGIS geoalgorithms which have two or more arguments of type multipleinput.

Pls note that when using the QGIS nightly version, the first line of `qgis_run()` returns again the current working directory under Windows, hence, it would be desirable to adjust `qgis_configure()` accordingly (see #32).