### PR TITLE
fixed regex to match qgis version in qgis_query_version()

### DIFF
--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -204,7 +204,7 @@ qgis_env <- function() {
 qgis_query_version <- function(quiet = FALSE) {
   result <- qgis_run(args = character(0))
   lines <- readLines(textConnection(result$stdout))
-  match <- stringr::str_match(lines, "\\(([0-9.]+[A-Za-z0-9.-]*)\\)")[, 2, drop = TRUE]
+  match <- stringr::str_match(lines, "\\(([0-9.]+[[:cntrl:][:alnum:].-]*)\\)")[, 2, drop = TRUE]
   if (all(is.na(match))) {
     abort(
       message(


### PR DESCRIPTION
A new regex was used to match the name of QGIS version when uses non-ascii characters. I tested in Windows 10 and Linux Ubuntu 20.04 with good results!