### PR TITLE
Add support for QGIS crs and extent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(
              comment = c(ORCID = "0000-0001-5679-6536")),
       person(given = "Jan",
              family = "Caha",
-             role = c("ctb"))
+             role = c("aut"))
     )
 Description: Provides seamless access to the 'QGIS' <https://qgis.org/>
   processing toolbox using the 'qgis_process' command-line utility.

--- a/R/compat-raster.R
+++ b/R/compat-raster.R
@@ -97,3 +97,21 @@ qgis_as_brick.qgis_result <- function(output, ...) {
 
   abort("Can't extract brick from result: zero outputs of type 'outputRaster' or 'outputLayer'.")
 }
+
+#' @export
+as_qgis_argument.CRS <- function(x, spec = qgis_argument_spec()) {
+  if (!isTRUE(spec$qgis_type %in% c("crs"))) {
+    abort(glue("Can't convert 'crs' object to QGIS type '{ spec$qgis_type }'"))
+  }
+
+  raster::wkt(x)
+}
+
+#' @export
+as_qgis_argument.Extent <- function(x, spec = qgis_argument_spec()) {
+  if (!isTRUE(spec$qgis_type %in% c("extent"))) {
+    abort(glue("Can't convert 'Extent' object to QGIS type '{ spec$qgis_type }'"))
+  }
+
+  glue("{x@xmin},{x@xmax},{x@ymin},{x@ymax}")
+}

--- a/R/compat-sf.R
+++ b/R/compat-sf.R
@@ -26,3 +26,33 @@ st_as_sf.qgis_result <- function(x, ...) {
 
   abort("Can't extract sf object from result: zero outputs of type 'outputVector' or 'outputLayer'.")
 }
+
+#'
+#' @inheritParams as_qgis_argument
+#'
+#' @export
+#'
+as_qgis_argument.crs <- function(x, spec = qgis_argument_spec()) {
+  if (!isTRUE(spec$qgis_type %in% c("crs"))) {
+    abort(glue("Can't convert 'crs' object to QGIS type '{ spec$qgis_type }'"))
+  }
+
+  x$Wkt
+}
+
+#'
+#' @inheritParams as_qgis_argument
+#'
+#' @export
+#'
+as_qgis_argument.bbox <- function(x, spec = qgis_argument_spec()) {
+  if (!isTRUE(spec$qgis_type %in% c("extent"))) {
+    abort(glue("Can't convert 'bbox' object to QGIS type '{ spec$qgis_type }'"))
+  }
+
+  if (!is.na(sf::st_crs(x)$epsg)){
+    glue("{x$xmin},{x$xmax},{x$ymin},{x$ymax}[EPSG:{sf::st_crs(x)$epsg}]")
+  }else{
+    glue("{x$xmin},{x$xmax},{x$ymin},{x$ymax}")
+  }
+}

--- a/tests/testthat/test-compat-raster.R
+++ b/tests/testthat/test-compat-raster.R
@@ -121,7 +121,7 @@ test_that("raster crs work", {
   expect_is(crs_representation, "character")
 })
 
-test_that("raster bbox work", {
+test_that("raster extent work", {
   skip_if_not_installed("raster")
   skip_if_not_installed("rgdal")
 
@@ -134,4 +134,18 @@ test_that("raster bbox work", {
   )
 
   expect_is(bbox_representation, "character")
+})
+
+test_that("raster crs and extent work", {
+  skip_if_not_installed("raster")
+  skip_if_not_installed("rgdal")
+
+  obj <- raster::raster(system.file("longlake/longlake.tif", package = "qgisprocess"))
+
+
+  result <- qgis_run_algorithm("native:createconstantrasterlayer",
+                               EXTENT = raster::extent(obj),
+                               TARGET_CRS = raster::crs(obj),
+                               PIXEL_SIZE = 1000,
+                               NUMBER=5)
 })

--- a/tests/testthat/test-compat-raster.R
+++ b/tests/testthat/test-compat-raster.R
@@ -105,3 +105,33 @@ test_that("raster result coercers work", {
     "RasterBrick"
   )
 })
+
+test_that("raster crs work", {
+  skip_if_not_installed("raster")
+  skip_if_not_installed("rgdal")
+
+  obj <- raster::raster(system.file("longlake/longlake.tif", package = "qgisprocess"))
+
+
+  crs_representation <- expect_match(
+    as_qgis_argument(raster::crs(obj), qgis_argument_spec(qgis_type = "crs")),
+    "North American Datum 1983"
+  )
+
+  expect_is(crs_representation, "character")
+})
+
+test_that("raster bbox work", {
+  skip_if_not_installed("raster")
+  skip_if_not_installed("rgdal")
+
+  obj <- raster::raster(system.file("longlake/longlake.tif", package = "qgisprocess"))
+
+
+  bbox_representation <- expect_match(
+    as_qgis_argument(raster::extent(obj), qgis_argument_spec(qgis_type = "extent")),
+    "409891\\.446955431,411732\\.936955431,5083288\\.89932423,5084852\\.61932423"
+  )
+
+  expect_is(bbox_representation, "character")
+})

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -37,3 +37,44 @@ test_that("sf objects can be extracted from a qgis_result", {
   result$OUTPUT <- NULL
   expect_error(sf::st_as_sf(result), "Can't extract sf object.")
 })
+
+test_that("sf crs work", {
+  skip_if_not_installed("sf")
+  sf_obj <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))
+
+
+  crs_representation <- expect_match(
+    as_qgis_argument(sf::st_crs(sf_obj), qgis_argument_spec(qgis_type = "crs")),
+    "^GEOGCS"
+  )
+
+  expect_is(crs_representation, "character")
+
+})
+
+test_that("sf bbox work", {
+  skip_if_not_installed("sf")
+  sf_obj <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))
+
+
+  bbox_representation <- expect_match(
+    as_qgis_argument(sf::st_bbox(sf_obj), qgis_argument_spec(qgis_type = "extent")),
+    "-84\\.3238525390625,-75\\.4569778442383,33\\.8819923400879,36\\.5896492004395\\[EPSG:4267\\]"
+  )
+
+  expect_is(bbox_representation, "character")
+
+})
+
+test_that("sf crs and bbox work", {
+  skip_if_not_installed("sf")
+
+  sf_obj <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))
+
+  result <- qgis_run_algorithm("native:createconstantrasterlayer",
+                               EXTENT = sf::st_bbox(sf_obj),
+                               TARGET_CRS = sf::st_crs(5514),
+                               PIXEL_SIZE = 1000,
+                               NUMBER=5,
+                               .quiet = TRUE)
+})


### PR DESCRIPTION
Solves two input types (crs, extent) from list in #13.

Includes tests.  