### PR TITLE
More informative startup & config messages

### DIFF
--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -83,9 +83,13 @@ qgis_configure <- function(quiet = FALSE) {
     if (!quiet) message(glue::glue("QGIS version: { version }"))
 
     algo <- qgis_algorithms(query = TRUE, quiet = quiet)
-    if (!quiet) message(glue::glue("Metadata of { nrow(algo) } algorithms ",
-                                   "queried and stored in cache.\n",
-                                   "Run `qgis_algorithms()` to see them."))
+    if (!quiet) {
+      message(
+        glue::glue(
+          "Metadata of { nrow(algo) } algorithms queried and stored in cache.\n",
+          "Run `qgis_algorithms()` to see them.")
+        )
+    }
   }, error = function(e) {
     qgis_unconfigure()
     if (!quiet) message(e)

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -87,8 +87,9 @@ qgis_configure <- function(quiet = FALSE) {
       message(
         glue::glue(
           "Metadata of { nrow(algo) } algorithms queried and stored in cache.\n",
-          "Run `qgis_algorithms()` to see them.")
+          "Run `qgis_algorithms()` to see them."
         )
+      )
     }
   }, error = function(e) {
     qgis_unconfigure()

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -78,8 +78,14 @@ qgis_configure <- function(quiet = FALSE) {
     qgis_unconfigure()
 
     qgis_path(query = TRUE, quiet = quiet)
-    qgis_version(query = TRUE, quiet = quiet)
-    qgis_algorithms(query = TRUE, quiet = quiet)
+
+    version <- qgis_version(query = TRUE, quiet = quiet)
+    if (!quiet) message(glue::glue("QGIS version: { version }"))
+
+    algo <- qgis_algorithms(query = TRUE, quiet = quiet)
+    if (!quiet) message(glue::glue("Metadata of { nrow(algo) } algorithms ",
+                                   "queried and stored in cache.\n",
+                                   "Run `qgis_algorithms()` to see them."))
   }, error = function(e) {
     qgis_unconfigure()
     if (!quiet) message(e)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,11 +22,13 @@
 .onAttach <- function(...) {
   if (has_qgis()) {
     packageStartupMessage(
-      glue::glue("Using 'qgis_process' at '{ qgis_path() }'.",
-                 "QGIS version: { qgis_version() }",
-                 "Metadata of { nrow(qgis_algorithms()) } algorithms successfully cached.",
-                 "Run `qgis_configure()` for details.",
-                 .sep = "\n")
+      glue::glue(
+        "Using 'qgis_process' at '{ qgis_path() }'.",
+        "QGIS version: { qgis_version() }",
+        "Metadata of { nrow(qgis_algorithms()) } algorithms successfully cached.",
+        "Run `qgis_configure()` for details.",
+        .sep = "\n"
+      )
     )
   } else {
     packageStartupMessage(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,7 +22,11 @@
 .onAttach <- function(...) {
   if (has_qgis()) {
     packageStartupMessage(
-      glue::glue("Using 'qgis_process' at '{ qgis_path() }'.\nRun `qgis_configure()` for details.")
+      glue::glue("Using 'qgis_process' at '{ qgis_path() }'.",
+                 "QGIS version: { qgis_version() }",
+                 "Metadata of { nrow(qgis_algorithms()) } algorithms successfully cached.",
+                 "Run `qgis_configure()` for details.",
+                 .sep = "\n")
     )
   } else {
     packageStartupMessage(


### PR DESCRIPTION
Currently we get:

```r
> library(qgisprocess)
Using 'qgis_process' at '/usr/bin/qgis_process'.
Run `qgis_configure()` for details.

> qgis_configure()
getOption('qgisprocess.path') was not found.
Trying Sys.getenv('R_QGISPROCESS_PATH'): '/usr/bin/qgis_process'
Success!
```

These are fine messages of course, but as a user I was curious why `qgis_configure()`, hence also `library(qgisprocess)` takes multiple seconds to finish, even after setting `R_QGISPROCESS_PATH`.  It seemed that `qgis_configure()` still took some seconds to finish after 'Success!' being printed. The explanation is simple from the code; the step that takes most time appears to be `qgis_algorithms(query = TRUE)`. So here's a suggestion to make this a little more explicit in the messages, which I think will make the user understand better this delay.

With this PR one gets something like:

``` r
library(qgisprocess)
#> Using 'qgis_process' at '/usr/bin/qgis_process'.
#> QGIS version: 3.20.1-Odense
#> Metadata of 623 algorithms successfully cached.
#> Run `qgis_configure()` for details.
qgis_configure()
#> getOption('qgisprocess.path') was not found.
#> Trying Sys.getenv('R_QGISPROCESS_PATH'): '/usr/bin/qgis_process'
#> Success!
#> QGIS version: 3.20.1-Odense
#> Metadata of 623 algorithms queried and stored in cache.
#> Run `qgis_algorithms()` to see them.
```

<sup>Created on 2021-08-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 4.1.0 (2021-05-18)
#>  os       Linux Mint 20               
#>  system   x86_64, linux-gnu           
#>  ui       X11                         
#>  language nl_BE:nl                    
#>  collate  nl_BE.UTF-8                 
#>  ctype    nl_BE.UTF-8                 
#>  tz       Europe/Brussels             
#>  date     2021-08-06                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date       lib source        
#>  cli           2.5.0      2021-04-26 [1] CRAN (R 4.1.0)
#>  crayon        1.4.1      2021-02-08 [1] CRAN (R 4.1.0)
#>  digest        0.6.27     2020-10-24 [1] CRAN (R 4.1.0)
#>  ellipsis      0.3.2      2021-04-29 [1] CRAN (R 4.1.0)
#>  evaluate      0.14       2019-05-28 [1] CRAN (R 4.1.0)
#>  fansi         0.5.0      2021-05-25 [1] CRAN (R 4.1.0)
#>  fs            1.5.0      2020-07-31 [1] CRAN (R 4.1.0)
#>  glue          1.4.2      2020-08-27 [1] CRAN (R 4.1.0)
#>  highr         0.9        2021-04-16 [1] CRAN (R 4.1.0)
#>  htmltools     0.5.1.1    2021-01-22 [1] CRAN (R 4.1.0)
#>  knitr         1.33       2021-04-24 [1] CRAN (R 4.1.0)
#>  lifecycle     1.0.0      2021-02-15 [1] CRAN (R 4.1.0)
#>  magrittr      2.0.1      2020-11-17 [1] CRAN (R 4.1.0)
#>  pillar        1.6.1      2021-05-16 [1] CRAN (R 4.1.0)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.1.0)
#>  processx      3.5.2      2021-04-30 [1] CRAN (R 4.1.0)
#>  ps            1.6.0      2021-02-28 [1] CRAN (R 4.1.0)
#>  qgisprocess * 0.0.0.9000 2021-08-06 [1] local         
#>  R6            2.5.0      2020-10-28 [1] CRAN (R 4.1.0)
#>  reprex        2.0.0      2021-04-02 [1] CRAN (R 4.1.0)
#>  rlang         0.4.11     2021-04-30 [1] CRAN (R 4.1.0)
#>  rmarkdown     2.8        2021-05-07 [1] CRAN (R 4.1.0)
#>  rstudioapi    0.13       2020-11-12 [1] CRAN (R 4.1.0)
#>  sessioninfo   1.1.1      2018-11-05 [1] CRAN (R 4.1.0)
#>  stringi       1.6.2      2021-05-17 [1] CRAN (R 4.1.0)
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 4.1.0)
#>  tibble        3.1.2      2021-05-16 [1] CRAN (R 4.1.0)
#>  utf8          1.2.1      2021-03-12 [1] CRAN (R 4.1.0)
#>  vctrs         0.3.8      2021-04-29 [1] CRAN (R 4.1.0)
#>  withr         2.4.2      2021-04-18 [1] CRAN (R 4.1.0)
#>  xfun          0.23       2021-05-15 [1] CRAN (R 4.1.0)
#>  yaml          2.2.1      2020-02-01 [1] CRAN (R 4.1.0)
#> 
#> [1] /home/floris/lib/R/library
#> [2] /usr/local/lib/R/site-library
#> [3] /usr/lib/R/site-library
#> [4] /usr/lib/R/library
```

</details>

Meanwhile reported the QGIS version, I believe that fits well.

Do you find this sensible? Feel free to improve further.