### PR TITLE
Implementation of Point argument

### DIFF
--- a/R/compat-sf.R
+++ b/R/compat-sf.R
@@ -56,3 +56,43 @@ as_qgis_argument.bbox <- function(x, spec = qgis_argument_spec()) {
     glue("{x$xmin},{x$xmax},{x$ymin},{x$ymax}")
   }
 }
+
+#'
+#' @inheritParams as_qgis_argument
+#'
+#' @export
+#'
+as_qgis_argument.sfc <- function(x, spec = qgis_argument_spec()) {
+
+  if (!isTRUE(spec$qgis_type %in% c("point"))) {
+    abort(glue("Can't convert 'sfc' object to QGIS type '{ spec$qgis_type }'"))
+  }
+
+  if (isTRUE(length(x) != 1)){
+    abort(glue("Can't convert 'sfc' object to QGIS type '{ spec$qgis_type }' as the length is not equal to 1"))
+  }
+
+  if (isTRUE((sf::st_geometry_type(x) != "POINT"))){
+    abort(glue("Can't convert 'sfc' object to QGIS type '{ spec$qgis_type }' as type is not 'POINT'"))
+  }
+
+  if (!is.na(sf::st_crs(x)$epsg)){
+    glue("{x[[1]][1]},{x[[1]][2]}[EPSG:{sf::st_crs(x)$epsg}]")
+  }else{
+    glue("{x[[1]][1]},{x[[1]][2]}")
+  }
+}
+
+#'
+#' @inheritParams as_qgis_argument
+#'
+#' @export
+#'
+as_qgis_argument.POINT <- function(x, spec = qgis_argument_spec()) {
+
+  if (!isTRUE(spec$qgis_type %in% c("point"))) {
+    abort(glue("Can't convert 'POINT' object to QGIS type '{ spec$qgis_type }'"))
+  }
+
+  glue("{x[1]},{x[2]}")
+}

--- a/R/compat-sf.R
+++ b/R/compat-sf.R
@@ -6,13 +6,18 @@
 #' @export
 #'
 as_qgis_argument.sf <- function(x, spec = qgis_argument_spec()) {
-  if (!isTRUE(spec$qgis_type %in% c("source", "layer", "vector", "multilayer"))) {
+  if (!isTRUE(spec$qgis_type %in% c("source", "layer", "vector", "multilayer", "point"))) {
     abort(glue("Can't convert 'sf' object to QGIS type '{ spec$qgis_type }'"))
   }
 
-  path <- qgis_tmp_vector()
-  sf::write_sf(x, path)
-  structure(path, class = "qgis_tempfile_arg")
+  if (spec$qgis_type == "point"){
+    as_qgis_argument(sf::st_geometry(x), spec=spec)
+  }
+  else{
+    path <- qgis_tmp_vector()
+    sf::write_sf(x, path)
+    structure(path, class = "qgis_tempfile_arg")
+  }
 }
 
 # dynamically registered in zzz.R

--- a/R/compat-sf.R
+++ b/R/compat-sf.R
@@ -10,10 +10,9 @@ as_qgis_argument.sf <- function(x, spec = qgis_argument_spec()) {
     abort(glue("Can't convert 'sf' object to QGIS type '{ spec$qgis_type }'"))
   }
 
-  if (spec$qgis_type == "point"){
+  if (spec$qgis_type == "point") {
     as_qgis_argument(sf::st_geometry(x), spec=spec)
-  }
-  else{
+  } else {
     path <- qgis_tmp_vector()
     sf::write_sf(x, path)
     structure(path, class = "qgis_tempfile_arg")

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -91,7 +91,7 @@ test_that("sfc to QGIS point work", {
 
   skip_if_not_installed("sf")
 
-  point <- sf::st_sfc(sf::st_point(c(1, 2)), crs = st_crs("EPSG:5514"))
+  point <- sf::st_sfc(sf::st_point(c(1, 2)), crs = sf::st_crs("EPSG:5514"))
 
   point_representation <- expect_match(
     as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
@@ -116,7 +116,7 @@ test_that("sfc to QGIS point rasises issues", {
 
   skip_if_not_installed("sf")
 
-  points <- sf::st_sfc(list(sf::st_point(c(1, 2)),sf::st_point(c(1, 2))), crs = st_crs("EPSG:5514"))
+  points <- sf::st_sfc(list(sf::st_point(c(1, 2)),sf::st_point(c(1, 2))), crs = sf::st_crs("EPSG:5514"))
 
   expect_error(as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
                "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -86,3 +86,57 @@ test_that("sf crs and bbox work", {
   expect_true(file.exists(result$OUTPUT))
   qgis_result_clean(result)
 })
+
+test_that("sfc to QGIS point work", {
+
+  skip_if_not_installed("sf")
+
+  point <- sf::st_sfc(sf::st_point(c(1, 2)), crs = st_crs("EPSG:5514"))
+
+  point_representation <- expect_match(
+    as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
+    "1,2\\[EPSG:5514\\]"
+  )
+
+  expect_is(point_representation, "character")
+
+  skip_if_not_installed("sf")
+
+  point <- sf::st_sfc(sf::st_point(c(1, 2)))
+
+  point_representation <- expect_match(
+    as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
+    "1,2"
+  )
+
+  expect_is(point_representation, "character")
+})
+
+test_that("sfc to QGIS point rasises issues", {
+
+  skip_if_not_installed("sf")
+
+  points <- sf::st_sfc(list(sf::st_point(c(1, 2)),sf::st_point(c(1, 2))), crs = st_crs("EPSG:5514"))
+
+  expect_error(as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
+               "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
+
+  points <- sf::st_sfc(st_multipoint(matrix(1:15, , 3)), crs = st_crs("EPSG:5514"))
+
+  expect_error(as_qgis_argument(points, qgis_argument_spec(qgis_type = "point")),
+               "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")
+})
+
+test_that("POINT to QGIS point work", {
+
+  skip_if_not_installed("sf")
+
+  point <- sf::st_point(c(1, 2))
+
+  point_representation <- expect_match(
+    as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
+    "1,2"
+  )
+
+  expect_is(point_representation, "character")
+})

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -183,7 +183,7 @@ test_that("sf to QGIS point work", {
     as_qgis_argument(
       points,
       qgis_argument_spec(qgis_type = "point")),
-    "1265036\\.90059085,985175\\.481905457\\[EPSG:32019\\]")
+    "1265036\\.90059[0-9]+,985175\\.481905[0-9]+\\[EPSG:32019\\]")
 
   expect_is(point_representation, "character")
 })

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -121,7 +121,7 @@ test_that("sfc to QGIS point rasises issues", {
   expect_error(as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
                "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
 
-  points <- sf::st_sfc(st_multipoint(matrix(1:15, , 3)), crs = st_crs("EPSG:5514"))
+  points <- sf::st_sfc(st_multipoint(matrix(1:15, , 3)), crs = sf::st_crs("EPSG:5514"))
 
   expect_error(as_qgis_argument(points, qgis_argument_spec(qgis_type = "point")),
                "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -118,10 +118,10 @@ test_that("sfc to QGIS point rasises issues", {
 
   points <- sf::st_sfc(list(sf::st_point(c(1, 2)),sf::st_point(c(1, 2))), crs = sf::st_crs("EPSG:5514"))
 
-  expect_error(as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
+  expect_error(as_qgis_argument(points, qgis_argument_spec(qgis_type = "point")),
                "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
 
-  points <- sf::st_sfc(st_multipoint(matrix(1:15, , 3)), crs = sf::st_crs("EPSG:5514"))
+  points <- sf::st_sfc(sf::st_multipoint(matrix(1:15, , 3)), crs = sf::st_crs("EPSG:5514"))
 
   expect_error(as_qgis_argument(points, qgis_argument_spec(qgis_type = "point")),
                "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -122,7 +122,8 @@ test_that("sfc to QGIS point rasises issues", {
     as_qgis_argument(
       points,
       qgis_argument_spec(qgis_type = "point")),
-    "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
+    "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1"
+  )
 
   points <- sf::st_sfc(sf::st_multipoint(matrix(1:15, , 3)), crs = sf::st_crs("EPSG:5514"))
 
@@ -130,7 +131,8 @@ test_that("sfc to QGIS point rasises issues", {
     as_qgis_argument(
       points,
       qgis_argument_spec(qgis_type = "point")),
-    "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")
+    "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'"
+  )
 })
 
 test_that("sf to QGIS point rasises issues", {
@@ -142,16 +144,20 @@ test_that("sf to QGIS point rasises issues", {
   expect_error(
     as_qgis_argument(
       points,
-      qgis_argument_spec(qgis_type = "point")),
-    "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
+      qgis_argument_spec(qgis_type = "point")
+    ),
+    "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1"
+  )
 
   points <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))[1,]
 
   expect_error(
     as_qgis_argument(
       points,
-      qgis_argument_spec(qgis_type = "point")),
-    "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")
+      qgis_argument_spec(qgis_type = "point")
+    ),
+    "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'"
+  )
 })
 
 test_that("POINT to QGIS point work", {
@@ -182,7 +188,8 @@ test_that("sf to QGIS point work", {
   point_representation <- expect_match(
     as_qgis_argument(
       points,
-      qgis_argument_spec(qgis_type = "point")),
+      qgis_argument_spec(qgis_type = "point")
+    ),
     "1265036\\.90059[0-9]+,985175\\.481905[0-9]+\\[EPSG:32019\\]")
 
   expect_is(point_representation, "character")

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -183,7 +183,7 @@ test_that("sf to QGIS point work", {
     as_qgis_argument(
       points,
       qgis_argument_spec(qgis_type = "point")),
-    "1265036\\.90059085,985175\\.481905458\\[EPSG:32019\\]")
+    "1265036\\.90059085,985175\\.481905457\\[EPSG:32019\\]")
 
   expect_is(point_representation, "character")
 })

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -133,6 +133,27 @@ test_that("sfc to QGIS point rasises issues", {
     "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")
 })
 
+test_that("sf to QGIS point rasises issues", {
+
+  skip_if_not_installed("sf")
+
+  points <- sf::st_centroid(sf::read_sf(system.file("shape/nc.shp", package = "sf")))
+
+  expect_error(
+    as_qgis_argument(
+      points,
+      qgis_argument_spec(qgis_type = "point")),
+    "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
+
+  points <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))[1,]
+
+  expect_error(
+    as_qgis_argument(
+      points,
+      qgis_argument_spec(qgis_type = "point")),
+    "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")
+})
+
 test_that("POINT to QGIS point work", {
 
   skip_if_not_installed("sf")
@@ -143,6 +164,26 @@ test_that("POINT to QGIS point work", {
     as_qgis_argument(point, qgis_argument_spec(qgis_type = "point")),
     "1,2"
   )
+
+  expect_is(point_representation, "character")
+})
+
+test_that("sf to QGIS point work", {
+
+  skip_if_not_installed("sf")
+
+  data <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))
+  data <- sf::st_transform(data, sf::st_crs("EPSG:32019"))
+
+  suppressWarnings(
+    points <- sf::st_centroid(data[1,])
+  )
+
+  point_representation <- expect_match(
+    as_qgis_argument(
+      points,
+      qgis_argument_spec(qgis_type = "point")),
+    "1265036\\.90059085,985175\\.481905458\\[EPSG:32019\\]")
 
   expect_is(point_representation, "character")
 })

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -139,7 +139,9 @@ test_that("sf to QGIS point rasises issues", {
 
   skip_if_not_installed("sf")
 
-  points <- sf::st_centroid(sf::read_sf(system.file("shape/nc.shp", package = "sf")))
+  suppressWarnings(
+    points <- sf::st_centroid(sf::read_sf(system.file("shape/nc.shp", package = "sf")))
+  )
 
   expect_error(
     as_qgis_argument(

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -118,13 +118,19 @@ test_that("sfc to QGIS point rasises issues", {
 
   points <- sf::st_sfc(list(sf::st_point(c(1, 2)),sf::st_point(c(1, 2))), crs = sf::st_crs("EPSG:5514"))
 
-  expect_error(as_qgis_argument(points, qgis_argument_spec(qgis_type = "point")),
-               "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
+  expect_error(
+    as_qgis_argument(
+      points,
+      qgis_argument_spec(qgis_type = "point")),
+    "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1")
 
   points <- sf::st_sfc(sf::st_multipoint(matrix(1:15, , 3)), crs = sf::st_crs("EPSG:5514"))
 
-  expect_error(as_qgis_argument(points, qgis_argument_spec(qgis_type = "point")),
-               "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")
+  expect_error(
+    as_qgis_argument(
+      points,
+      qgis_argument_spec(qgis_type = "point")),
+    "Can't convert 'sfc' object to QGIS type 'point' as type is not 'POINT'")
 })
 
 test_that("POINT to QGIS point work", {


### PR DESCRIPTION
This allows passing point as input parameter to QGIS. Point is accepted as `sfc` with length 1 and geometry type `POINT`, so that user can also pass CRS, or as `POINT` without CRS.

Includes tests.