### PR TITLE
qgis_sanitize_arguments(): fix loss of special arguments

### DIFF
--- a/R/qgis-arguments.R
+++ b/R/qgis-arguments.R
@@ -55,11 +55,14 @@ qgis_sanitize_arguments <- function(algorithm, ..., .algorithm_arguments = qgis_
       message(glue("Ignoring unknown input '{ arg_name }'"))
     }
   }
+  special_args <- user_args[c("PROJECT_PATH", "ELLIPSOID")]
+  special_args <- special_args[!sapply(special_args, is.null)]
 
   # generate argument list template and populate user-supplied values
   args <- rep(list(qgis_default_value()), nrow(arg_meta))
   names(args) <- arg_meta$name
   args[intersect(names(args), names(user_args))] <- user_args[intersect(names(args), names(user_args))]
+  args <- c(args, special_args)
 
   # get argument specs to pass to as_qgis_argument()
   arg_spec <- Map(

--- a/tests/testthat/test-qgis-arguments.R
+++ b/tests/testthat/test-qgis-arguments.R
@@ -13,6 +13,21 @@ test_that("qgis_sanitize_arguments() ignores unknown inputs", {
   )
 })
 
+test_that("qgis_sanitize_arguments() doesn't drop special arguments", {
+  special <- list(PROJECT_PATH = "some_path", ELLIPSOID = "some_ellipse")
+  for (i in 1:3) {
+    if (i == 3) i <- 1:2
+    expect_identical(
+      qgis_sanitize_arguments(
+        "some_algorithm",
+        !!!special[i],
+        .algorithm_arguments = tibble::tibble(name = character())
+      ),
+      !!special[i]
+    )
+  }
+})
+
 test_that("qgis_sanitize_arguments() accepts multiple input arguments", {
   sanitized <- qgis_sanitize_arguments(
     "some_algorithm",

--- a/tests/testthat/test-qgis-arguments.R
+++ b/tests/testthat/test-qgis-arguments.R
@@ -7,7 +7,7 @@ test_that("qgis_sanitize_arguments() ignores unknown inputs", {
         unknown_arg = 1,
         .algorithm_arguments = tibble::tibble(name = character())
       ),
-      rlang::set_names(list(), character())
+      list()
     ),
     "Ignoring unknown input"
   )


### PR DESCRIPTION
This tries to solve #75. Because in `qgis_sanitize_arguments()`, the step that matches user arguments against algorithm arguments drops the special `ELLIPSOID` and `PROJECT_PATH` arguments, the latter were not passed to the `qgis_process` command.

@thierryO can you give this a try?