### PR TITLE
qgis_detect_windows(): also search for qgis_process LTR

### DIFF
--- a/R/qgis-detect.R
+++ b/R/qgis-detect.R
@@ -16,7 +16,12 @@ qgis_detect_windows <- function(drive_letter = strsplit(R.home(), ":")[[1]][1]) 
     abort("Can't use `qgis_detect_windows()` on a non-windows platform.")
   }
 
-  bat_files <- c("qgis_process-qgis.bat", "qgis_process-qgis-dev.bat")
+  bat_files <-
+    c(
+      "qgis_process-qgis.bat",
+      "qgis_process-qgis-ltr.bat",
+      "qgis_process-qgis-dev.bat"
+      )
   posssible_locs_win_df <- expand.grid(
     qgis = c(
       list.files(glue::glue("{ drive_letter }:/Program Files"), "QGIS*", full.names = TRUE),

--- a/R/qgis-detect.R
+++ b/R/qgis-detect.R
@@ -16,12 +16,12 @@ qgis_detect_windows <- function(drive_letter = strsplit(R.home(), ":")[[1]][1]) 
     abort("Can't use `qgis_detect_windows()` on a non-windows platform.")
   }
 
-  bat_files <-
-    c(
-      "qgis_process-qgis.bat",
-      "qgis_process-qgis-ltr.bat",
-      "qgis_process-qgis-dev.bat"
-      )
+  bat_files <- c(
+    "qgis_process-qgis.bat",
+    "qgis_process-qgis-ltr.bat",
+    "qgis_process-qgis-dev.bat"
+  )
+
   posssible_locs_win_df <- expand.grid(
     qgis = c(
       list.files(glue::glue("{ drive_letter }:/Program Files"), "QGIS*", full.names = TRUE),


### PR DESCRIPTION
Fixes #81:

```r
> qgis_configure()
getOption('qgisprocess.path') was not found.
Sys.getenv('R_QGISPROCESS_PATH') was not found.
Trying 'qgis_process' on PATH
Error in processx::run("cmd.exe", c("/c", "call", path, args), ...): System command 'cmd.exe' failed, exit status: 1, stderr:
E> 'qgis_process' is not recognized as an internal or external command,
E> operable program or batch file.

Found 1 QGIS installation containing 'qgis_process':
 C:/Program Files/QGIS 3.16/bin/qgis_process-qgis-ltr.bat
Trying command 'C:/Program Files/QGIS 3.16/bin/qgis_process-qgis-ltr.bat'
Success!
QGIS version: 3.16.16-Hannover
Saving configuration to 'C:\Users\FLORIS~1\AppData\Local/R-qgisprocess/R-qgisprocess/Cache/cache-0.0.0.9000.rds'
Metadata of 984 algorithms queried and stored in cache.
Run `qgis_algorithms()` to see them.
- Using JSON for output serialization
```