### PR TITLE
qgis_arguments(): support character type element

### DIFF
--- a/R/qgis-help.R
+++ b/R/qgis-help.R
@@ -26,6 +26,15 @@ qgis_description <- function(algorithm) {
   )
 }
 
+#' @keywords internal
+extract_type_component <- function(param_element, component) {
+  type <- param_element[["type"]]
+  if (length(type) == 1L && inherits(type, "character")) {
+    if (component == "id") return(type) else return(NULL)
+  }
+  type[[component]]
+}
+
 #' @rdname qgis_show_help
 #' @export
 qgis_arguments <- function(algorithm) {
@@ -34,10 +43,10 @@ qgis_arguments <- function(algorithm) {
     out <- tibble::tibble(
       name = names(help$parameters),
       description = vapply(help$parameters, "[[", character(1), "description"),
-      qgis_type = vapply(help$parameters, "[[", character(1), c("type", "id")),
+      qgis_type = vapply(help$parameters, extract_type_component, character(1), "id"),
       default_value = lapply(help$parameters, "[[", "default_value"),
       available_values = lapply(help$parameters, "[[", c("raw_definition", "options")),
-      acceptable_values = lapply(help$parameters, "[[", c("type", "acceptable_values"))
+      acceptable_values = lapply(help$parameters, extract_type_component, "acceptable_values")
     )
 
     out[] <- lapply(out, unname)

--- a/tests/testthat/test-qgis-help.R
+++ b/tests/testthat/test-qgis-help.R
@@ -31,6 +31,27 @@ test_that("qgis_description() works for algorithms", {
   }
 })
 
+test_that("qgis_arguments() and qgis_outputs() work for selected algorithms", {
+  skip_if_not(has_qgis())
+
+  selected_algorithms <- c("native:buffer", "qgis:executesql")
+
+  for (algorithm in selected_algorithms) {
+    if (interactive()) message(algorithm)
+    expect_is(qgis_arguments(!! algorithm), "data.frame")
+    expect_false(any(is.na(qgis_arguments(!! algorithm)$name)))
+    expect_false(any(is.na(qgis_arguments(!! algorithm)$qgis_type)))
+    expect_false(any(is.na(qgis_arguments(!! algorithm)$description)))
+  }
+
+  for (algorithm in selected_algorithms) {
+    expect_is(qgis_outputs(!! algorithm), "data.frame")
+    expect_false(any(is.na(qgis_outputs(!! algorithm)$name)))
+    expect_false(any(is.na(qgis_outputs(!! algorithm)$qgis_output_type)))
+  }
+
+})
+
 test_that("qgis_arguments() and qgis_outputs() works for all algorithms", {
   skip("Test takes ~1 hr to run")
   for (algorithm in qgis_algorithms()$algorithm) {

--- a/tests/testthat/test-qgis-help.R
+++ b/tests/testthat/test-qgis-help.R
@@ -37,7 +37,6 @@ test_that("qgis_arguments() and qgis_outputs() work for selected algorithms", {
   selected_algorithms <- c("native:buffer", "qgis:executesql")
 
   for (algorithm in selected_algorithms) {
-    if (interactive()) message(algorithm)
     expect_is(qgis_arguments(!! algorithm), "data.frame")
     expect_false(any(is.na(qgis_arguments(!! algorithm)$name)))
     expect_false(any(is.na(qgis_arguments(!! algorithm)$qgis_type)))


### PR DESCRIPTION
For some algorithms, the `type` element in each parameter of `qgis_help(algorithm)$parameters` is a string instead of a list with an `id` element, and could probably serve as `id` directly. This causes issue #85 when running `qgis_arguments()`, i.e. when `qgisprocess.use_json_output = TRUE`.

This PR tries to fix #85 by taking those cases into account; an internal function is added to extract elements from the `type` element, and is used instead of applying `[[`.

A test has been added to include the result for `qgis:executesql`.

Current result (`INPUT_QUERY` is the parameter where it went wrong):

```r
> qgis_arguments("qgis:executesql")
# A tibble: 7 × 6
  name                 description        qgis_type default_value available_values acceptable_valu…
  <chr>                <chr>              <chr>     <list>        <list>           <list>          
1 INPUT_DATASOURCES    Additional input … multilay… <NULL>        <NULL>           <list [0]>      
2 INPUT_QUERY          SQL query          execute_… <NULL>        <NULL>           <NULL>          
3 INPUT_UID_FIELD      Unique identifier… string    <NULL>        <NULL>           <chr [1]>       
4 INPUT_GEOMETRY_FIELD Geometry field     string    <NULL>        <NULL>           <chr [1]>       
5 INPUT_GEOMETRY_TYPE  Geometry type      enum      <NULL>        <chr [8]>        <chr [2]>       
6 INPUT_GEOMETRY_CRS   CRS                crs       <NULL>        <NULL>           <chr [4]>       
7 OUTPUT               SQL Output         sink      <NULL>        <NULL>           <chr [1]>             
```

I didn't actually check whether this result (with a `NULL` as acceptable value!) poses a problem for `qgis_run_algorithm("qgis:executesql")`.