### PR TITLE
qgis_query_path(): turn error into neutral msg (fixes #95)

### DIFF
--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -221,13 +221,13 @@ qgis_query_path <- function(quiet = FALSE) {
     if (!quiet) message("Sys.getenv('R_QGISPROCESS_PATH') was not found.")
   }
 
-  if (!quiet) message(glue::glue("Trying 'qgis_process' on PATH"))
+  if (!quiet) message(glue::glue("Trying 'qgis_process' on PATH..."))
   tryCatch({
     qgis_run(path = "qgis_process")
     if (!quiet) message("Success!")
     return("qgis_process")
   }, error = function(e) {
-    if (!quiet) message(as.character(e))
+    if (!quiet) message("'qgis_process' is not available on PATH.")
   })
 
   possible_locs <- if (is_macos()) {


### PR DESCRIPTION
This turns the message from #95 into:

```r
> qgis_path(query = TRUE, quiet = FALSE)
getOption('qgisprocess.path') was not found.
Sys.getenv('R_QGISPROCESS_PATH') was not found.
Trying 'qgis_process' on PATH...
'qgis_process' is not available on PATH.
Found 1 QGIS installation containing 'qgis_process':
 C:/Program Files/QGIS 3.16/bin/qgis_process-qgis-ltr.bat
Trying command 'C:/Program Files/QGIS 3.16/bin/qgis_process-qgis-ltr.bat'
Success!
[1] "C:/Program Files/QGIS 3.16/bin/qgis_process-qgis-ltr.bat"
```