### PR TITLE
qgis_query_version(): support version codenames with a whitespace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Imports: 
     processx (>= 3.5.2),
     stringr,

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -326,8 +326,10 @@ qgis_query_version <- function(quiet = FALSE) {
   match <- stringr::str_match(lines, "\\(([0-9.]+[[:cntrl:][:alnum:].?-]*)\\)")[, 2, drop = TRUE]
   if (all(is.na(match))) {
     abort(
-      "Output did not contain expected version information and was:\n\n",
-      paste(lines, collapse = "\n")
+      paste0(
+        "Output did not contain expected version information and was:\n\n",
+        paste(lines, collapse = "\n")
+      )
     )
   }
   match[!is.na(match)]

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -323,7 +323,7 @@ qgis_env <- function() {
 qgis_query_version <- function(quiet = FALSE) {
   result <- qgis_run(args = character(0))
   lines <- readLines(textConnection(result$stdout))
-  match <- stringr::str_match(lines, "\\(([0-9.]+[[:cntrl:][:alnum:].?-]*)\\)")[, 2, drop = TRUE]
+  match <- stringr::str_match(lines, "\\((\\d{1,2}\\.\\d+.*-.+)\\)")[, 2, drop = TRUE]
   if (all(is.na(match))) {
     abort(
       paste0(

--- a/man/qgisprocess-package.Rd
+++ b/man/qgisprocess-package.Rd
@@ -6,7 +6,7 @@
 \alias{qgisprocess-package}
 \title{qgisprocess: Use 'QGIS' Processing Algorithms}
 \description{
-Provides seamless access to the 'QGIS' <https://qgis.org/> processing toolbox using the 'qgis_process' command-line utility.
+Provides seamless access to the 'QGIS' \url{https://qgis.org/} processing toolbox using the 'qgis_process' command-line utility.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -2,7 +2,7 @@
 test_that("qgis_version() works", {
   skip_if_not(has_qgis())
 
-  expect_match(qgis_version(), "^3\\.")
+  expect_match(qgis_version(), "^\\d{1,2}\\.\\d+.*-.+")
 })
 
 test_that("qgis_algorithms() works", {

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -5,6 +5,12 @@ test_that("qgis_version() works", {
   expect_match(qgis_version(), "^\\d{1,2}\\.\\d+.*-.+")
 })
 
+test_that("qgis_query_version() works", {
+  skip_if_not(has_qgis())
+
+  expect_match(qgis_query_version(), "^\\d{1,2}\\.\\d+.*-.+")
+})
+
 test_that("qgis_algorithms() works", {
   skip_if_not(has_qgis())
 


### PR DESCRIPTION
Attempt to fix #103.

- `qgis_query_version()`: fix the `abort()` message in case the version regex doesn't match
- `qgis_query_version()`: use a new regex, still depending on `qgis_process`'s output formatting with the version within parentheses and including a hyphen
- updating the test for `qgis_version()`, based on this regex and allowing versions up to QGIS 99.x :slightly_smiling_face:
- adding a test for `qgis_query_version()`

You can install this development version by running `remotes::install_github("paleolimbot/qgisprocess@5bd5f0b")`.

Please respond whether this fixes #103.

I get:

```r
> qgis_query_version()
[1] "3.26.1-Buenos Aires"
```

``` r
qgisprocess::qgis_configure()
#> getOption('qgisprocess.path') was not found.
#> Trying Sys.getenv('R_QGISPROCESS_PATH'): '/usr/bin/qgis_process'
#> Success!
#> QGIS version: 3.26.1-Buenos Aires
#> Saving configuration to '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
#> Metadata of 1024 algorithms queried and stored in cache.
#> Run `qgis_algorithms()` to see them.
#> - Using JSON for input serialization
#> - Using JSON for output serialization
```

<sup>Created on 2022-08-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.1 (2022-06-23)
#>  os       Linux Mint 20
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language nl_BE:nl
#>  collate  nl_BE.UTF-8
#>  ctype    nl_BE.UTF-8
#>  tz       Europe/Brussels
#>  date     2022-08-11
#>  pandoc   2.18 @ /usr/lib/rstudio/bin/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.3.0      2022-04-25 [1] CRAN (R 4.2.0)
#>  digest        0.6.29     2021-12-01 [1] CRAN (R 4.2.0)
#>  evaluate      0.16       2022-08-09 [1] CRAN (R 4.2.1)
#>  fansi         1.0.3      2022-03-24 [1] CRAN (R 4.2.0)
#>  fastmap       1.1.0      2021-01-25 [1] CRAN (R 4.2.0)
#>  fs            1.5.2      2021-12-08 [1] CRAN (R 4.2.0)
#>  glue          1.6.2      2022-02-24 [1] CRAN (R 4.2.0)
#>  highr         0.9        2021-04-16 [1] CRAN (R 4.2.0)
#>  htmltools     0.5.3      2022-07-18 [1] RSPM (R 4.2.1)
#>  jsonlite      1.8.0      2022-02-22 [1] CRAN (R 4.2.0)
#>  knitr         1.39       2022-04-26 [1] CRAN (R 4.2.0)
#>  lifecycle     1.0.1      2021-09-24 [1] CRAN (R 4.2.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.2.0)
#>  pillar        1.8.0      2022-07-18 [1] RSPM (R 4.2.1)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.2.0)
#>  processx      3.7.0      2022-07-07 [1] RSPM (R 4.2.1)
#>  ps            1.7.1      2022-06-18 [1] RSPM (R 4.2.1)
#>  qgisprocess   0.0.0.9000 2022-08-11 [1] Github (paleolimbot/qgisprocess@5bd5f0b)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.2.0)
#>  rappdirs      0.3.3      2021-01-31 [1] CRAN (R 4.2.0)
#>  reprex        2.0.1      2021-08-05 [1] CRAN (R 4.2.0)
#>  rlang         1.0.4      2022-07-12 [1] RSPM (R 4.2.1)
#>  rmarkdown     2.14       2022-04-25 [1] CRAN (R 4.2.0)
#>  rstudioapi    0.13       2020-11-12 [1] CRAN (R 4.2.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.2.0)
#>  stringi       1.7.8      2022-07-11 [1] RSPM (R 4.2.1)
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 4.2.0)
#>  tibble        3.1.8      2022-07-22 [1] RSPM (R 4.2.1)
#>  utf8          1.2.2      2021-07-24 [1] CRAN (R 4.2.0)
#>  vctrs         0.4.1      2022-04-13 [1] CRAN (R 4.2.0)
#>  withr         2.5.0      2022-03-03 [1] CRAN (R 4.2.0)
#>  xfun          0.32       2022-08-10 [1] CRAN (R 4.2.1)
#>  yaml          2.3.5      2022-02-21 [1] CRAN (R 4.2.0)
#> 
#>  [1] /home/floris/lib/R/library
#>  [2] /usr/local/lib/R/site-library
#>  [3] /usr/lib/R/site-library
#>  [4] /usr/lib/R/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

