### PR TITLE
GHA workflows: update QGIS Signing Key

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install QGIS (Ubuntu Nightly)
         if: matrix.config.qgis == 'ubuntu-nightly'
         run: |
-          wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
+          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
           sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
           sudo add-apt-repository "deb https://qgis.org/ubuntu-nightly `lsb_release -c -s` main"
           sudo apt-get update
@@ -56,7 +56,7 @@ jobs:
       - name: Install QGIS (Ubuntu)
         if: matrix.config.qgis == 'ubuntu'
         run: |
-          wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
+          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
           sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
           sudo add-apt-repository "deb https://qgis.org/ubuntu `lsb_release -c -s` main"
           sudo apt-get update

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install QGIS (Ubuntu)
         run: |
-          wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
+          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
           sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
           sudo add-apt-repository "deb https://qgis.org/ubuntu `lsb_release -c -s` main"
           sudo apt-get update


### PR DESCRIPTION
This will fix the failing tests in #105; the '2021' signing key was still in use but has presumably expired. Switched to the key currently advertised at qgis.org.

Merging right away, since this fix succeeded in a dummy fork (https://github.com/florisvdh/qgisprocess/pull/1).