### PR TITLE
Check for QGIS version & path changes; update messages

### DIFF
--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -98,11 +98,25 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
           "qgisprocess.path",
           Sys.getenv("R_QGISPROCESS_PATH")
         )
+
         if (identical(option_path, "") || identical(option_path, cached_data$path)) {
 
           if (!quiet) message(glue(
             "Checking cached QGIS version with version reported by '{cached_data$path}' ..."
           ))
+
+          # since we will query the program, first check that it still works
+
+          tryCatch({
+            qgis_run(path = cached_data$path)
+          }, error = function(e) {
+            abort(
+              glue(
+                "'{cached_data$path}' (cached path) is not available anymore.\n",
+                "Will try to reconfigure qgisprocess and build new cache ..."
+              )
+            )
+          })
 
           # note the difference with the further qgis_version() statement,
           # where it will also respect the outcome of qgis_path(query = TRUE);

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -138,9 +138,21 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
 
             return(invisible(TRUE))
 
+          } else {
+            message(glue(
+              "QGIS version change detected:\n",
+              "- in the qgisprocess cache it was: {cached_data$version}\n",
+              "- while '{cached_data$path}' is at {qversion}"
+            ))
           }
-
+        } else {
+          message(glue(
+            "The user's qgisprocess.path option or the R_QGISPROCESS_PATH environment ",
+            "variable specify a different qgis_process path ({option_path}) ",
+            "than the cache did ({cached_data$path})."))
         }
+
+        message("Hence rebuilding cache to reflect this change.")
       })
     }
 

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -121,6 +121,21 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
             qgisprocess_cache$algorithms <- cached_data$algorithms
             qgisprocess_cache$loaded_from <- cache_data_file
 
+            if (!quiet) {
+              message(
+                glue::glue(
+                  "Metadata of { nrow(cached_data$algorithms) } algorithms are present in cache.\n",
+                  "Run `qgis_algorithms()` to see them."
+                )
+              )
+              if (qgis_use_json_input()) {
+                message("- Using JSON for input serialization.")
+              }
+              if (qgis_use_json_output()) {
+                message("- Using JSON for output serialization.")
+              }
+            }
+
             return(invisible(TRUE))
 
           }
@@ -164,11 +179,11 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
       )
 
       if (qgis_use_json_input()) {
-        message("- Using JSON for input serialization")
+        message("- Using JSON for input serialization.")
       }
 
       if (qgis_use_json_output()) {
-        message("- Using JSON for output serialization")
+        message("- Using JSON for output serialization.")
       }
     }
   }, error = function(e) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,9 +21,16 @@
 
 .onAttach <- function(...) {
   if (has_qgis()) {
+    path <- qgis_path()
+    pathstring <-
+      if (path == "qgis_process") {
+        "in the system PATH"
+      } else {
+        glue("at '{path}'")
+    }
     packageStartupMessage(
       glue(
-        "Using 'qgis_process' at '{ qgis_path() }'.\n",
+        "Using 'qgis_process' {pathstring}.\n",
         "QGIS version: { qgis_version() }\n",
         if (is.null(qgisprocess_cache$loaded_from)) {
           paste0(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -43,8 +43,8 @@
             "Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.\n"
           )
         },
-        ">>> If you need another installed QGIS version, run `qgis_configure()`; see ",
-        "its documentation if you need to preset the path of qgis_process.\n",
+        ">>> If you need another installed QGIS version, run `qgis_configure()`;\n",
+        "    see its documentation if you need to preset the path of qgis_process.\n",
         if (qgis_use_json_input()) "- Using JSON for input serialization.\n" else "",
         if (qgis_use_json_output()) "- Using JSON for output serialization.\n" else "",
         .sep = ""

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -45,7 +45,9 @@
     )
   } else {
     packageStartupMessage(
-      "The 'qgis_process' command-line utility was not found.\nRun `qgis_configure()` for details."
+      "The 'qgis_process' command-line utility was not found.\n",
+      "Please run `qgis_configure()` to fix this and rebuild the cache.\n",
+      "See its documentation if you need to preset the path of qgis_process."
     )
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -38,8 +38,8 @@
         },
         ">>> If you need another installed QGIS version, run `qgis_configure()`; see ",
         "its documentation if you need to preset the path of qgis_process.\n",
-        if (qgis_use_json_input()) "Using JSON for input serialization\n" else "",
-        if (qgis_use_json_output()) "Using JSON for output serialization\n" else "",
+        if (qgis_use_json_input()) "- Using JSON for input serialization.\n" else "",
+        if (qgis_use_json_output()) "- Using JSON for output serialization.\n" else "",
         .sep = ""
       )
     )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,11 +26,18 @@
         "Using 'qgis_process' at '{ qgis_path() }'.\n",
         "QGIS version: { qgis_version() }\n",
         if (is.null(qgisprocess_cache$loaded_from)) {
-          "Metadata of { nrow(qgis_algorithms()) } algorithms successfully cached\n"
+          paste0(
+            "Metadata of { nrow(qgis_algorithms()) } algorithms successfully cached.\n",
+            "Run `qgis_algorithms()` to see them.\n"
+          )
         } else {
-          "Configuration loaded from '{ qgisprocess_cache$loaded_from }'\n"
+          paste0(
+            "Configuration loaded from '{ qgisprocess_cache$loaded_from }'\n",
+            "Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.\n"
+          )
         },
-        "Run `qgis_configure()` for details.\n",
+        ">>> If you need another installed QGIS version, run `qgis_configure()`; see ",
+        "its documentation if you need to preset the path of qgis_process.\n",
         if (qgis_use_json_input()) "Using JSON for input serialization\n" else "",
         if (qgis_use_json_output()) "Using JSON for output serialization\n" else "",
         .sep = ""


### PR DESCRIPTION
Fixes #94, fixes #109.

Please feel free to suggest improvements.

### Checking for QGIS version change in `qgisprocess_cache$path` when loading cache

When a cache is going to be used, the QGIS version is first compared between the cache version and that of the program in the path defined by the cache. It makes the package take a little more time to load, but this seems worth it, since conflicts are expected (outdated cached algorithms) if a version change at the same location is not captured.

If versions differ, the cache will not be used and a new cache is built. Startup messages make this clear. The reprex below first overwrites an existing cache rds file, in order to mimic an outdated cache upon loading **qgisprocess**.

``` r
# Artificially outdating the cache to mimic version difference
suppressPackageStartupMessages(library(qgisprocess))
cache_data_file <- qgisprocess:::qgisprocess_cache$loaded_from
qgisprocess:::qgisprocess_cache$version
#> [1] "3.26.1-Buenos Aires"
qc <- qgisprocess:::qgisprocess_cache
qc$version <- "3.22.3-Białowieża"
saveRDS(qc, cache_data_file)
detach("package:qgisprocess", unload = TRUE)

# Loading and attaching qgisprocess
library(qgisprocess)
#> QGIS version change detected:
#> - in the qgisprocess cache it was: 3.22.3-Białowieża
#> - while 'qgis_process' is at 3.26.1-Buenos Aires
#> Hence rebuilding cache to reflect this change.
#> Using 'qgis_process' at 'qgis_process'.
#> QGIS version: 3.26.1-Buenos Aires
#> Metadata of 1024 algorithms successfully cached.
#> Run `qgis_algorithms()` to see them.
#> >>> If you need another installed QGIS version, run `qgis_configure()`; see its documentation if you need to preset the path of qgis_process.
#> - Using JSON for input serialization.
#> - Using JSON for output serialization.
```

<sup>Created on 2022-08-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>



### Further tweaks of messages

- As seen above, startup messaging doesn't advise to run `qgis_configure()` when a cache has been rebuilt; instead `qgis_algorithms()` is referred.
- In any case, startup messaging adds a hint (after '>>>') for reconfiguring if another QGIS version is needed.
- If an existing cache was loaded, `qgis_configure(use_cached_data = TRUE)` is referred for more details:

``` r
library(qgisprocess)
#> Using 'qgis_process' at 'qgis_process'.
#> QGIS version: 3.26.1-Buenos Aires
#> Configuration loaded from '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
#> Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.
#> >>> If you need another installed QGIS version, run `qgis_configure()`; see its documentation if you need to preset the path of qgis_process.
#> - Using JSON for input serialization.
#> - Using JSON for output serialization.
```

<sup>Created on 2022-08-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


- Upon loading **qgisprocess**, `qgis_configure()` is called with argument `quiet=TRUE` (this was and remains so). Its default is `FALSE`; if the user calls `qgis_configure(use_cached_data = TRUE)`, the version check is reported:

``` r
suppressPackageStartupMessages(library(qgisprocess))
qgis_configure(use_cached_data = TRUE)
#> Checking configuration from '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
#> Checking cached QGIS version with version reported by '/usr/bin/qgis_process' ...
#> QGIS versions match! (3.26.1-Buenos Aires)
#> Restoring configuration from '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
#> Metadata of 1024 algorithms are present in cache.
#> Run `qgis_algorithms()` to see them.
#> - Using JSON for input serialization.
#> - Using JSON for output serialization.
```

<sup>Created on 2022-08-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>



- If the cache is rebuilt because the `qgisprocess.path` option or `R_QGISPROCESS_PATH` environmental variable contain a different path than the cache, this is reported at startup, just like the case of a version change:

``` r
options("qgisprocess.path" = "/usr/bin/qgis_process")
library(qgisprocess)
#> The user's qgisprocess.path option or the R_QGISPROCESS_PATH environment variable specify a different qgis_process path (/usr/bin/qgis_process) than the cache did (qgis_process).
#> Hence rebuilding cache to reflect this change.
#> Using 'qgis_process' at '/usr/bin/qgis_process'.
#> QGIS version: 3.26.1-Buenos Aires
#> Metadata of 1024 algorithms successfully cached.
#> Run `qgis_algorithms()` to see them.
#> >>> If you need another installed QGIS version, run `qgis_configure()`; see its documentation if you need to preset the path of qgis_process.
#> - Using JSON for input serialization.
#> - Using JSON for output serialization.
```

<sup>Created on 2022-08-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


- Since upon loading the package using the cache, the `qgis_process` program _as referred by the cached path_ is queried to do the cache-version check, the program must be available. This is checked first and if this errors, it is reported and reconfiguration is triggered:

``` r
# Artificially outdating the cache to mimic (re)moved qgis_process installation
suppressPackageStartupMessages(library(qgisprocess))
cache_data_file <- qgisprocess:::qgisprocess_cache$loaded_from
qgisprocess:::qgisprocess_cache$path
#> [1] "/usr/bin/qgis_process"
qc <- qgisprocess:::qgisprocess_cache
qc$path <- "/bin/qgis_process"
saveRDS(qc, cache_data_file)
detach("package:qgisprocess", unload = TRUE)

# Loading and attaching qgisprocess
library(qgisprocess)
#> Error in value[[3L]](cond) : 
#>   '/bin/qgis_process' (cached path) is not available anymore.
#> Will try to reconfigure qgisprocess and build new cache ...
#> Using 'qgis_process' at 'qgis_process'.
#> QGIS version: 3.26.1-Buenos Aires
#> Metadata of 1024 algorithms successfully cached.
#> Run `qgis_algorithms()` to see them.
#> >>> If you need another installed QGIS version, run `qgis_configure()`; see its documentation if you need to preset the path of qgis_process.
#> - Using JSON for input serialization.
#> - Using JSON for output serialization.
```

<sup>Created on 2022-08-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.1 (2022-06-23)
#>  os       Linux Mint 20
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language nl_BE:nl
#>  collate  nl_BE.UTF-8
#>  ctype    nl_BE.UTF-8
#>  tz       Europe/Brussels
#>  date     2022-08-19
#>  pandoc   2.18 @ /usr/lib/rstudio/bin/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.3.0      2022-04-25 [1] CRAN (R 4.2.0)
#>  digest        0.6.29     2021-12-01 [1] CRAN (R 4.2.0)
#>  evaluate      0.16       2022-08-09 [1] CRAN (R 4.2.1)
#>  fansi         1.0.3      2022-03-24 [1] CRAN (R 4.2.0)
#>  fastmap       1.1.0      2021-01-25 [1] CRAN (R 4.2.0)
#>  fs            1.5.2      2021-12-08 [1] CRAN (R 4.2.0)
#>  glue          1.6.2      2022-02-24 [1] CRAN (R 4.2.0)
#>  highr         0.9        2021-04-16 [1] CRAN (R 4.2.0)
#>  htmltools     0.5.3      2022-07-18 [1] RSPM (R 4.2.1)
#>  jsonlite      1.8.0      2022-02-22 [1] CRAN (R 4.2.0)
#>  knitr         1.39       2022-04-26 [1] CRAN (R 4.2.0)
#>  lifecycle     1.0.1      2021-09-24 [1] CRAN (R 4.2.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.2.0)
#>  pillar        1.8.0      2022-07-18 [1] RSPM (R 4.2.1)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.2.0)
#>  processx      3.7.0      2022-07-07 [1] RSPM (R 4.2.1)
#>  ps            1.7.1      2022-06-18 [1] RSPM (R 4.2.1)
#>  qgisprocess * 0.0.0.9000 2022-08-19 [1] Github (paleolimbot/qgisprocess@f24e90a)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.2.0)
#>  rappdirs      0.3.3      2021-01-31 [1] CRAN (R 4.2.0)
#>  reprex        2.0.1      2021-08-05 [1] CRAN (R 4.2.0)
#>  rlang         1.0.4      2022-07-12 [1] RSPM (R 4.2.1)
#>  rmarkdown     2.14       2022-04-25 [1] CRAN (R 4.2.0)
#>  rstudioapi    0.13       2020-11-12 [1] CRAN (R 4.2.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.2.0)
#>  stringi       1.7.8      2022-07-11 [1] RSPM (R 4.2.1)
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 4.2.0)
#>  tibble        3.1.8      2022-07-22 [1] RSPM (R 4.2.1)
#>  utf8          1.2.2      2021-07-24 [1] CRAN (R 4.2.0)
#>  vctrs         0.4.1      2022-04-13 [1] CRAN (R 4.2.0)
#>  withr         2.5.0      2022-03-03 [1] CRAN (R 4.2.0)
#>  xfun          0.32       2022-08-10 [1] CRAN (R 4.2.1)
#>  yaml          2.3.5      2022-02-21 [1] CRAN (R 4.2.0)
#> 
#>  [1] /home/floris/lib/R/library
#>  [2] /usr/local/lib/R/site-library
#>  [3] /usr/lib/R/site-library
#>  [4] /usr/lib/R/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

