### PR TITLE
Support PROJECT_PATH and ELLIPSOID arguments when using JSON input

### DIFF
--- a/R/qgis-arguments.R
+++ b/R/qgis-arguments.R
@@ -95,15 +95,18 @@ qgis_sanitize_arguments <- function(algorithm, ..., .algorithm_arguments = qgis_
   args_sanitized
 }
 
+
+#' @keywords internal
+unclass_recursive <- function(x) {
+  is_list <- vapply(x, is.list, logical(1))
+  x[is_list] <- lapply(x[is_list], unclass_recursive)
+  lapply(x, unclass)
+}
+
+
 # turn sanitized arguments into command-line arguments
 qgis_serialize_arguments <- function(arguments, use_json_input = FALSE) {
   if (use_json_input) {
-    unclass_recursive <- function(x) {
-      is_list <- vapply(x, is.list, logical(1))
-      x[is_list] <- lapply(x[is_list], unclass_recursive)
-      lapply(x, unclass)
-    }
-
     jsonlite::toJSON(list(inputs = unclass_recursive(arguments)), auto_unbox = TRUE)
   } else {
     args_dict <- vapply(arguments, inherits, logical(1), "qgis_dict_input")

--- a/R/qgis-arguments.R
+++ b/R/qgis-arguments.R
@@ -107,7 +107,15 @@ unclass_recursive <- function(x) {
 # turn sanitized arguments into command-line arguments
 qgis_serialize_arguments <- function(arguments, use_json_input = FALSE) {
   if (use_json_input) {
-    jsonlite::toJSON(list(inputs = unclass_recursive(arguments)), auto_unbox = TRUE)
+    arguments <- unclass_recursive(arguments)
+    arglist <-
+      list(
+        inputs = arguments[!(names(arguments) %in% c("ELLIPSOID", "PROJECT_PATH"))],
+        ellipsoid = arguments$ELLIPSOID,
+        project_path = arguments$PROJECT_PATH
+      )
+    arglist <- arglist[!vapply(arglist, is.null, logical(1))]
+    jsonlite::toJSON(arglist, auto_unbox = TRUE)
   } else {
     args_dict <- vapply(arguments, inherits, logical(1), "qgis_dict_input")
     if (any(args_dict)) {

--- a/tests/testthat/test-qgis-arguments.R
+++ b/tests/testthat/test-qgis-arguments.R
@@ -49,6 +49,66 @@ test_that("qgis_sanitize_arguments() accepts multiple input arguments", {
   )
 })
 
+test_that("qgis_serialize_arguments() outputs correct JSON strings", {
+  arguments <- list(
+    LAYOUT = "Layout 1",
+    TEXT_FORMAT = 0,
+    OUTPUT = "output.pdf",
+    PROJECT_PATH = "test.qgs",
+    AGGREGATES = list(
+      list(
+        aggregate = "first_value",
+        delimiter = ",",
+        input = '"admin"',
+        length = 36,
+        name = "admin",
+        precision = 0,
+        type = 10
+      ),
+      list(
+        aggregate = "concatenate",
+        delimiter = ",",
+        input = '"name"',
+        length = 3000,
+        name = "name",
+        precision = 0,
+        type = 10
+      )
+    )
+  )
+  json <- qgis_serialize_arguments(arguments = arguments, use_json_input = TRUE)
+  expect_identical(
+    jsonlite::fromJSON(json, simplifyVector = FALSE),
+    list(
+      inputs = list(
+        LAYOUT = "Layout 1",
+        TEXT_FORMAT = 0L,
+        OUTPUT = "output.pdf",
+        AGGREGATES = list(
+          list(
+            aggregate = "first_value",
+            delimiter = ",",
+            input = "\"admin\"",
+            length = 36L,
+            name = "admin",
+            precision = 0L,
+            type = 10L
+          ),
+          list(
+            aggregate = "concatenate",
+            delimiter = ",",
+            input = "\"name\"",
+            length = 3000L,
+            name = "name",
+            precision = 0L,
+            type = 10L
+            )
+          )
+        ),
+      project_path = "test.qgs")
+    )
+})
+
 test_that("argument coercers work", {
   expect_error(as_qgis_argument(list()), "Don't know how to convert object of type")
   expect_identical(as_qgis_argument("chr value"), "chr value")


### PR DESCRIPTION
Fixes #68. This should solve the problem with `PROJECT_PATH` and `ELLIPSOID` arguments when using JSON input (which is default for QGIS >= 3.23) (https://github.com/paleolimbot/qgisprocess/issues/68#issuecomment-1225318449). They must go into separate keys in the JSON string, not in the `inputs` key .

Related to https://github.com/qgis/QGIS/pull/49972.

``` r
library(qgisprocess)
#> Using 'qgis_process' in the system PATH.
#> QGIS version: 3.26.1-Buenos Aires
#> Configuration loaded from '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
#> Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.
#> >>> If you need another installed QGIS version, run `qgis_configure()`;
#>     see its documentation if you need to preset the path of qgis_process.
#> - Using JSON for input serialization.
#> - Using JSON for output serialization.

curl::curl_download(
  "https://gist.githubusercontent.com/paleolimbot/f2fa6f409c48c3d18fe5462fb29f8996/raw/3c1e14b7834c2175acbb6cb1b6f646906f9f89ed/test.qgs",
  "test.qgs"
)

qgis_run_algorithm(
  "native:printlayouttopdf",
  LAYOUT = "Layout 1",
  OUTPUT = "output.pdf",
  PROJECT_PATH = "test.qgs"
)
#> Argument `LAYERS` is unspecified (using QGIS default value).
#> Argument `DPI` is unspecified (using QGIS default value).
#> Argument `FORCE_VECTOR` is unspecified (using QGIS default value).
#> Argument `GEOREFERENCE` is unspecified (using QGIS default value).
#> Argument `INCLUDE_METADATA` is unspecified (using QGIS default value).
#> Argument `DISABLE_TILED` is unspecified (using QGIS default value).
#> Argument `SIMPLIFY` is unspecified (using QGIS default value).
#> Using `TEXT_FORMAT = "Always Export Text as Paths (Recommended)"`
#> Argument `SEPARATE_LAYERS` is unspecified (using QGIS default value).
#> JSON input ----
#> {
#>   "inputs": {
#>     "LAYOUT": "Layout 1",
#>     "TEXT_FORMAT": 0,
#>     "OUTPUT": "output.pdf"
#>   },
#>   "project_path": "test.qgs"
#> }
#> 
#> Running qgis_process --json run 'native:printlayouttopdf' -
#> qt5ct: using qt5ct plugin
#> Problem with OTB installation: OTB folder is not set.
#> <Result of `qgis_run_algorithm("native:printlayouttopdf", ...)`>
#> List of 1
#>  $ OUTPUT: 'qgis_outputFile' chr "output.pdf"

file.exists("output.pdf")
#> [1] TRUE
```

<sup>Created on 2022-08-26 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.1 (2022-06-23)
#>  os       Linux Mint 20
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language nl_BE:nl
#>  collate  nl_BE.UTF-8
#>  ctype    nl_BE.UTF-8
#>  tz       Europe/Brussels
#>  date     2022-08-26
#>  pandoc   2.18 @ /usr/lib/rstudio/bin/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.3.0      2022-04-25 [1] CRAN (R 4.2.0)
#>  curl          4.3.2      2021-06-23 [1] CRAN (R 4.2.0)
#>  digest        0.6.29     2021-12-01 [1] CRAN (R 4.2.0)
#>  evaluate      0.16       2022-08-09 [1] CRAN (R 4.2.1)
#>  fansi         1.0.3      2022-03-24 [1] CRAN (R 4.2.0)
#>  fastmap       1.1.0      2021-01-25 [1] CRAN (R 4.2.0)
#>  fs            1.5.2      2021-12-08 [1] CRAN (R 4.2.0)
#>  glue          1.6.2      2022-02-24 [1] CRAN (R 4.2.0)
#>  highr         0.9        2021-04-16 [1] CRAN (R 4.2.0)
#>  htmltools     0.5.3      2022-07-18 [1] RSPM (R 4.2.1)
#>  jsonlite      1.8.0      2022-02-22 [1] CRAN (R 4.2.0)
#>  knitr         1.39       2022-04-26 [1] CRAN (R 4.2.0)
#>  lifecycle     1.0.1      2021-09-24 [1] CRAN (R 4.2.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.2.0)
#>  pillar        1.8.0      2022-07-18 [1] RSPM (R 4.2.1)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.2.0)
#>  processx      3.7.0      2022-07-07 [1] RSPM (R 4.2.1)
#>  ps            1.7.1      2022-06-18 [1] RSPM (R 4.2.1)
#>  qgisprocess * 0.0.0.9000 2022-08-26 [1] local
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.2.0)
#>  rappdirs      0.3.3      2021-01-31 [1] CRAN (R 4.2.0)
#>  reprex        2.0.1      2021-08-05 [1] CRAN (R 4.2.0)
#>  rlang         1.0.4      2022-07-12 [1] RSPM (R 4.2.1)
#>  rmarkdown     2.14       2022-04-25 [1] CRAN (R 4.2.0)
#>  rstudioapi    0.13       2020-11-12 [1] CRAN (R 4.2.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.2.0)
#>  stringi       1.7.8      2022-07-11 [1] RSPM (R 4.2.1)
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 4.2.0)
#>  tibble        3.1.8      2022-07-22 [1] RSPM (R 4.2.1)
#>  utf8          1.2.2      2021-07-24 [1] CRAN (R 4.2.0)
#>  vctrs         0.4.1      2022-04-13 [1] CRAN (R 4.2.0)
#>  withr         2.5.0      2022-03-03 [1] CRAN (R 4.2.0)
#>  xfun          0.32       2022-08-10 [1] CRAN (R 4.2.1)
#>  yaml          2.3.5      2022-02-21 [1] CRAN (R 4.2.0)
#> 
#>  [1] /home/floris/lib/R/library
#>  [2] /usr/local/lib/R/site-library
#>  [3] /usr/lib/R/site-library
#>  [4] /usr/lib/R/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>