### PR TITLE
qgis_run_algorithm() tests: run them both with and without JSON input method

### DIFF
--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -43,6 +43,7 @@ test_that("sf objects can be extracted from a qgis_result", {
   expect_identical(result_sf, result_sf_alt)
 
   result$OUTPUT <- NULL
+  unlink("llbuffer.gpkg")
   expect_error(sf::st_as_sf(result), "Can't extract object.")
 })
 

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -1,8 +1,11 @@
 capture.output({
 
-  input <- if (qgis_use_json_input()) "(using JSON input)" else "(NOT using JSON input)"
+  input <-
+    if (has_qgis()) {
+      if (qgis_use_json_input()) " (using JSON input)" else " (NOT using JSON input)"
+    } else ""
 
-  test_that(glue("qgis_run_algorithm() works {input}"), {
+  test_that(glue("qgis_run_algorithm() works{input}"), {
     skip_if_not(has_qgis())
     skip_if_offline()
 
@@ -36,7 +39,7 @@ capture.output({
     unlink(tmp_gpkg)
   })
 
-  test_that(glue("qgis_run_algorithm() ignores unknown inputs {input}"), {
+  test_that(glue("qgis_run_algorithm() ignores unknown inputs{input}"), {
     skip_if_not(has_qgis())
 
     expect_message(
@@ -51,7 +54,7 @@ capture.output({
     )
   })
 
-  test_that(glue("qgis_run_algorithm accepts multiple input arguments {input}"), {
+  test_that(glue("qgis_run_algorithm accepts multiple input arguments{input}"), {
     skip_if_not(has_qgis())
     skip_if_not_installed("sf")
 
@@ -70,7 +73,7 @@ capture.output({
     expect_equal(nrow(tmp), 3)
   })
 
-  test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL {input}"), {
+  test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL{input}"), {
     skip_if_not(has_qgis())
 
     relief_args <- qgis_arguments("qgis:relief")
@@ -92,7 +95,7 @@ capture.output({
   })
 
 
-  test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project {input}"), {
+  test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"), {
     skip_if_not(has_qgis())
     skip_on_os("mac")
 

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -1,113 +1,113 @@
 capture.output({
 
-input <- if (qgis_use_json_input()) "(using JSON input)" else "(NOT using JSON input)"
+  input <- if (qgis_use_json_input()) "(using JSON input)" else "(NOT using JSON input)"
 
-test_that(glue("qgis_run_algorithm() works {input}"), {
-  skip_if_not(has_qgis())
-  skip_if_offline()
+  test_that(glue("qgis_run_algorithm() works {input}"), {
+    skip_if_not(has_qgis())
+    skip_if_offline()
 
-  tmp_gpkg <- qgis_tmp_vector(".gpkg")
+    tmp_gpkg <- qgis_tmp_vector(".gpkg")
 
-  result <- expect_output(
-    qgis_run_algorithm(
-      "native:reprojectlayer",
-      INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
-      TARGET_CRS = "EPSG:4326",
-      OUTPUT = tmp_gpkg,
-      .quiet = FALSE
-    ),
-    "Running\\s+"
-  )
-  expect_true(file.exists(tmp_gpkg))
+    result <- expect_output(
+      qgis_run_algorithm(
+        "native:reprojectlayer",
+        INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
+        TARGET_CRS = "EPSG:4326",
+        OUTPUT = tmp_gpkg,
+        .quiet = FALSE
+      ),
+      "Running\\s+"
+    )
+    expect_true(file.exists(tmp_gpkg))
 
-  unlink(tmp_gpkg)
+    unlink(tmp_gpkg)
 
-  result <- expect_output(
-    qgis_run_algorithm(
-      "native:reprojectlayer",
-      INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
-      TARGET_CRS = "EPSG:4326",
-      OUTPUT = tmp_gpkg,
+    result <- expect_output(
+      qgis_run_algorithm(
+        "native:reprojectlayer",
+        INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
+        TARGET_CRS = "EPSG:4326",
+        OUTPUT = tmp_gpkg,
+        .quiet = TRUE
+      ),
+      NA
+    )
+    expect_true(file.exists(tmp_gpkg))
+    unlink(tmp_gpkg)
+  })
+
+  test_that(glue("qgis_run_algorithm() ignores unknown inputs {input}"), {
+    skip_if_not(has_qgis())
+
+    expect_message(
+      qgis_run_algorithm(
+        "native:buffer",
+        NOT_AN_INPUT = "some value",
+        INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
+        DISTANCE = 100,
+        .quiet = TRUE
+      ),
+      "Ignoring unknown input"
+    )
+  })
+
+  test_that(glue("qgis_run_algorithm accepts multiple input arguments {input}"), {
+    skip_if_not(has_qgis())
+    skip_if_not_installed("sf")
+
+    v_1 <- sf::read_sf(system.file("longlake/longlake.gpkg", package = "qgisprocess"))
+    v_2 <- v_3 <- v_1
+    v_2$geom = v_2$geom + 1000
+    sf::st_crs(v_2) <- sf::st_crs(v_1)
+    v_3$geom <- v_3$geom - 1000
+    sf::st_crs(v_3) <- sf::st_crs(v_1)
+    out <- qgis_run_algorithm(
+      "native:mergevectorlayers",
+      LAYERS = v_1, LAYERS = v_2, LAYERS = v_3,
       .quiet = TRUE
-    ),
-    NA
-  )
-  expect_true(file.exists(tmp_gpkg))
-  unlink(tmp_gpkg)
-})
+    )
+    tmp <- sf::read_sf(qgis_output(out, "OUTPUT"))
+    expect_equal(nrow(tmp), 3)
+  })
 
-test_that(glue("qgis_run_algorithm() ignores unknown inputs {input}"), {
-  skip_if_not(has_qgis())
+  test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL {input}"), {
+    skip_if_not(has_qgis())
 
-  expect_message(
-    qgis_run_algorithm(
-      "native:buffer",
-      NOT_AN_INPUT = "some value",
-      INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
-      DISTANCE = 100,
-      .quiet = TRUE
-    ),
-    "Ignoring unknown input"
-  )
-})
+    relief_args <- qgis_arguments("qgis:relief")
+    expect_identical(relief_args["COLORS", ]$acceptable_values, list(NULL))
 
-test_that(glue("qgis_run_algorithm accepts multiple input arguments {input}"), {
-  skip_if_not(has_qgis())
-  skip_if_not_installed("sf")
-
-  v_1 <- sf::read_sf(system.file("longlake/longlake.gpkg", package = "qgisprocess"))
-  v_2 <- v_3 <- v_1
-  v_2$geom = v_2$geom + 1000
-  sf::st_crs(v_2) <- sf::st_crs(v_1)
-  v_3$geom <- v_3$geom - 1000
-  sf::st_crs(v_3) <- sf::st_crs(v_1)
-  out <- qgis_run_algorithm(
-    "native:mergevectorlayers",
-    LAYERS = v_1, LAYERS = v_2, LAYERS = v_3,
-    .quiet = TRUE
-  )
-  tmp <- sf::read_sf(qgis_output(out, "OUTPUT"))
-  expect_equal(nrow(tmp), 3)
-})
-
-test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL {input}"), {
-  skip_if_not(has_qgis())
-
-  relief_args <- qgis_arguments("qgis:relief")
-  expect_identical(relief_args["COLORS", ]$acceptable_values, list(NULL))
-
-  result <- qgis_run_algorithm(
-    "qgis:relief",
-    INPUT=system.file("longlake/longlake_depth.tif", package = "qgisprocess"),
-    Z_FACTOR=1,
-    AUTO_COLORS=FALSE,
-    COLORS="-0.5, 0, 170, 0, 0; 0, 0.5, 85, 255, 255; 0.5, 1, 0, 255, 0; 1, 2.5, 85, 85, 255"
+    result <- qgis_run_algorithm(
+      "qgis:relief",
+      INPUT=system.file("longlake/longlake_depth.tif", package = "qgisprocess"),
+      Z_FACTOR=1,
+      AUTO_COLORS=FALSE,
+      COLORS="-0.5, 0, 170, 0, 0; 0, 0.5, 85, 255, 255; 0.5, 1, 0, 255, 0; 1, 2.5, 85, 85, 255"
     )
 
-  expect_s3_class(result$OUTPUT, "qgis_outputRaster")
-  expect_s3_class(result$FREQUENCY_DISTRIBUTION, "qgis_outputFile")
-  expect_true(file.exists(result$OUTPUT))
-  expect_true(file.exists(result$FREQUENCY_DISTRIBUTION))
+    expect_s3_class(result$OUTPUT, "qgis_outputRaster")
+    expect_s3_class(result$FREQUENCY_DISTRIBUTION, "qgis_outputFile")
+    expect_true(file.exists(result$OUTPUT))
+    expect_true(file.exists(result$FREQUENCY_DISTRIBUTION))
 
-})
+  })
 
 
-test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project {input}"), {
-  skip_if_not(has_qgis())
-  skip_on_os("mac")
+  test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project {input}"), {
+    skip_if_not(has_qgis())
+    skip_on_os("mac")
 
-  tmp_pdf <- qgis_tmp_file(".pdf")
+    tmp_pdf <- qgis_tmp_file(".pdf")
 
-  result <- qgis_run_algorithm(
-    "native:printlayouttopdf",
-    LAYOUT = "Layout 1",
-    OUTPUT = tmp_pdf,
-    PROJECT_PATH = system.file("extdata/longlake.qgs", package = "qgisprocess")
-  )
+    result <- qgis_run_algorithm(
+      "native:printlayouttopdf",
+      LAYOUT = "Layout 1",
+      OUTPUT = tmp_pdf,
+      PROJECT_PATH = system.file("extdata/longlake.qgs", package = "qgisprocess")
+    )
 
-  expect_true(file.exists(tmp_pdf))
-  expect_identical(tmp_pdf, as.character(result$OUTPUT))
-  unlink(tmp_pdf)
-})
+    expect_true(file.exists(tmp_pdf))
+    expect_identical(tmp_pdf, as.character(result$OUTPUT))
+    unlink(tmp_pdf)
+  })
 
 })

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -1,84 +1,83 @@
-capture.output({
+input <-
+  if (has_qgis()) {
+    if (qgis_use_json_input()) " (using JSON input)" else " (NOT using JSON input)"
+  } else ""
 
-  input <-
-    if (has_qgis()) {
-      if (qgis_use_json_input()) " (using JSON input)" else " (NOT using JSON input)"
-    } else ""
+test_that(glue("qgis_run_algorithm() works{input}"), {
+  skip_if_not(has_qgis())
+  skip_if_offline()
 
-  test_that(glue("qgis_run_algorithm() works{input}"), {
-    skip_if_not(has_qgis())
-    skip_if_offline()
+  tmp_gpkg <- qgis_tmp_vector(".gpkg")
 
-    tmp_gpkg <- qgis_tmp_vector(".gpkg")
+  result <- expect_output(
+    qgis_run_algorithm(
+      "native:reprojectlayer",
+      INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
+      TARGET_CRS = "EPSG:4326",
+      OUTPUT = tmp_gpkg,
+      .quiet = FALSE
+    ),
+    "Running\\s+"
+  )
+  expect_true(file.exists(tmp_gpkg))
 
-    result <- expect_output(
-      qgis_run_algorithm(
-        "native:reprojectlayer",
-        INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
-        TARGET_CRS = "EPSG:4326",
-        OUTPUT = tmp_gpkg,
-        .quiet = FALSE
-      ),
-      "Running\\s+"
-    )
-    expect_true(file.exists(tmp_gpkg))
+  unlink(tmp_gpkg)
 
-    unlink(tmp_gpkg)
-
-    result <- expect_output(
-      qgis_run_algorithm(
-        "native:reprojectlayer",
-        INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
-        TARGET_CRS = "EPSG:4326",
-        OUTPUT = tmp_gpkg,
-        .quiet = TRUE
-      ),
-      NA
-    )
-    expect_true(file.exists(tmp_gpkg))
-    unlink(tmp_gpkg)
-  })
-
-  test_that(glue("qgis_run_algorithm() ignores unknown inputs{input}"), {
-    skip_if_not(has_qgis())
-
-    expect_message(
-      qgis_run_algorithm(
-        "native:buffer",
-        NOT_AN_INPUT = "some value",
-        INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
-        DISTANCE = 100,
-        .quiet = TRUE
-      ),
-      "Ignoring unknown input"
-    )
-  })
-
-  test_that(glue("qgis_run_algorithm accepts multiple input arguments{input}"), {
-    skip_if_not(has_qgis())
-    skip_if_not_installed("sf")
-
-    v_1 <- sf::read_sf(system.file("longlake/longlake.gpkg", package = "qgisprocess"))
-    v_2 <- v_3 <- v_1
-    v_2$geom = v_2$geom + 1000
-    sf::st_crs(v_2) <- sf::st_crs(v_1)
-    v_3$geom <- v_3$geom - 1000
-    sf::st_crs(v_3) <- sf::st_crs(v_1)
-    out <- qgis_run_algorithm(
-      "native:mergevectorlayers",
-      LAYERS = v_1, LAYERS = v_2, LAYERS = v_3,
+  result <- expect_output(
+    qgis_run_algorithm(
+      "native:reprojectlayer",
+      INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
+      TARGET_CRS = "EPSG:4326",
+      OUTPUT = tmp_gpkg,
       .quiet = TRUE
-    )
-    tmp <- sf::read_sf(qgis_output(out, "OUTPUT"))
-    expect_equal(nrow(tmp), 3)
-  })
+    ),
+    NA
+  )
+  expect_true(file.exists(tmp_gpkg))
+  unlink(tmp_gpkg)
+})
 
-  test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL{input}"), {
-    skip_if_not(has_qgis())
+test_that(glue("qgis_run_algorithm() ignores unknown inputs{input}"), {
+  skip_if_not(has_qgis())
 
-    relief_args <- qgis_arguments("qgis:relief")
-    expect_identical(relief_args["COLORS", ]$acceptable_values, list(NULL))
+  expect_message(
+    qgis_run_algorithm(
+      "native:buffer",
+      NOT_AN_INPUT = "some value",
+      INPUT = system.file("longlake/longlake.gpkg", package = "qgisprocess"),
+      DISTANCE = 100,
+      .quiet = TRUE
+    ),
+    "Ignoring unknown input"
+  )
+})
 
+test_that(glue("qgis_run_algorithm accepts multiple input arguments{input}"), {
+  skip_if_not(has_qgis())
+  skip_if_not_installed("sf")
+
+  v_1 <- sf::read_sf(system.file("longlake/longlake.gpkg", package = "qgisprocess"))
+  v_2 <- v_3 <- v_1
+  v_2$geom = v_2$geom + 1000
+  sf::st_crs(v_2) <- sf::st_crs(v_1)
+  v_3$geom <- v_3$geom - 1000
+  sf::st_crs(v_3) <- sf::st_crs(v_1)
+  out <- qgis_run_algorithm(
+    "native:mergevectorlayers",
+    LAYERS = v_1, LAYERS = v_2, LAYERS = v_3,
+    .quiet = TRUE
+  )
+  tmp <- sf::read_sf(qgis_output(out, "OUTPUT"))
+  expect_equal(nrow(tmp), 3)
+})
+
+test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL{input}"), {
+  skip_if_not(has_qgis())
+
+  relief_args <- qgis_arguments("qgis:relief")
+  expect_identical(relief_args["COLORS", ]$acceptable_values, list(NULL))
+
+  capture.output({
     result <- qgis_run_algorithm(
       "qgis:relief",
       INPUT=system.file("longlake/longlake_depth.tif", package = "qgisprocess"),
@@ -86,31 +85,32 @@ capture.output({
       AUTO_COLORS=FALSE,
       COLORS="-0.5, 0, 170, 0, 0; 0, 0.5, 85, 255, 255; 0.5, 1, 0, 255, 0; 1, 2.5, 85, 85, 255"
     )
-
-    expect_s3_class(result$OUTPUT, "qgis_outputRaster")
-    expect_s3_class(result$FREQUENCY_DISTRIBUTION, "qgis_outputFile")
-    expect_true(file.exists(result$OUTPUT))
-    expect_true(file.exists(result$FREQUENCY_DISTRIBUTION))
-
   })
 
+  expect_s3_class(result$OUTPUT, "qgis_outputRaster")
+  expect_s3_class(result$FREQUENCY_DISTRIBUTION, "qgis_outputFile")
+  expect_true(file.exists(result$OUTPUT))
+  expect_true(file.exists(result$FREQUENCY_DISTRIBUTION))
 
-  test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"), {
-    skip_if_not(has_qgis())
-    skip_on_os("mac")
+})
 
-    tmp_pdf <- qgis_tmp_file(".pdf")
 
+test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"), {
+  skip_if_not(has_qgis())
+  skip_on_os("mac")
+
+  tmp_pdf <- qgis_tmp_file(".pdf")
+
+  capture.output({
     result <- qgis_run_algorithm(
       "native:printlayouttopdf",
       LAYOUT = "Layout 1",
       OUTPUT = tmp_pdf,
       PROJECT_PATH = system.file("extdata/longlake.qgs", package = "qgisprocess")
     )
-
-    expect_true(file.exists(tmp_pdf))
-    expect_identical(tmp_pdf, as.character(result$OUTPUT))
-    unlink(tmp_pdf)
   })
 
+  expect_true(file.exists(tmp_pdf))
+  expect_identical(tmp_pdf, as.character(result$OUTPUT))
+  unlink(tmp_pdf)
 })

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -1,6 +1,8 @@
 capture.output({
 
-test_that("qgis_run_algorithm() works", {
+input <- if (qgis_use_json_input()) "(using JSON input)" else "(NOT using JSON input)"
+
+test_that(glue("qgis_run_algorithm() works {input}"), {
   skip_if_not(has_qgis())
   skip_if_offline()
 
@@ -34,7 +36,7 @@ test_that("qgis_run_algorithm() works", {
   unlink(tmp_gpkg)
 })
 
-test_that("qgis_run_algorithm() ignores unknown inputs", {
+test_that(glue("qgis_run_algorithm() ignores unknown inputs {input}"), {
   skip_if_not(has_qgis())
 
   expect_message(
@@ -49,7 +51,7 @@ test_that("qgis_run_algorithm() ignores unknown inputs", {
   )
 })
 
-test_that("qgis_run_algorithm accepts multiple input arguments", {
+test_that(glue("qgis_run_algorithm accepts multiple input arguments {input}"), {
   skip_if_not(has_qgis())
   skip_if_not_installed("sf")
 
@@ -68,7 +70,7 @@ test_that("qgis_run_algorithm accepts multiple input arguments", {
   expect_equal(nrow(tmp), 3)
 })
 
-test_that("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL", {
+test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptable value of COLORS is NULL {input}"), {
   skip_if_not(has_qgis())
 
   relief_args <- qgis_arguments("qgis:relief")
@@ -90,7 +92,7 @@ test_that("qgis_run_algorithm runs with qgis:relief, for which the acceptable va
 })
 
 
-test_that("qgis_run_algorithm succeeds when it needs a QGIS project", {
+test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project {input}"), {
   skip_if_not(has_qgis())
   skip_on_os("mac")
 

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -1,3 +1,4 @@
+capture.output({
 
 test_that("qgis_run_algorithm() works", {
   skip_if_not(has_qgis())
@@ -105,4 +106,6 @@ test_that("qgis_run_algorithm succeeds when it needs a QGIS project", {
   expect_true(file.exists(tmp_pdf))
   expect_identical(tmp_pdf, as.character(result$OUTPUT))
   unlink(tmp_pdf)
+})
+
 })

--- a/tests/testthat/test-qgis-run-algorithm2.R
+++ b/tests/testthat/test-qgis-run-algorithm2.R
@@ -1,9 +1,9 @@
 # Flip qgis_use_json_input() and rerun test-qgis-run-algorithm.R
 
+if (has_qgis() && package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.23.0") {
+
 withr::local_envvar(c(JSON_INPUT = qgis_use_json_input()))
 withr::local_options(qgisprocess.use_json_input = !qgis_use_json_input())
-
-if (has_qgis() && package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.23.0") {
 
   test_that("Flipping JSON input method before re-testing works", {
     expect_identical(

--- a/tests/testthat/test-qgis-run-algorithm2.R
+++ b/tests/testthat/test-qgis-run-algorithm2.R
@@ -1,0 +1,17 @@
+# Flip qgis_use_json_input() and rerun test-qgis-run-algorithm.R
+
+withr::local_envvar(c(JSON_INPUT = qgis_use_json_input()))
+withr::local_options(qgisprocess.use_json_input = !qgis_use_json_input())
+
+if (has_qgis() && package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.23.0") {
+
+  test_that("Flipping JSON input method before re-testing works", {
+    expect_identical(
+      as.logical(Sys.getenv("JSON_INPUT")),
+      !qgis_use_json_input()
+      )
+  })
+
+  source("test-qgis-run-algorithm.R", echo = FALSE, local = TRUE)
+
+}


### PR DESCRIPTION
This PR mainly focuses on `test-qgis-run-algorithm.R`:

- for QGIS >= 3.23, run this file twice, once with and once without the JSON input method. This is arranged by a separate test file `test-qgis-run-algorithm2.R` that temporarily flips the JSON input setting and re-runs `test-qgis-run-algorithm.R`.
- the output of `test_local()` and `test_file()` are cleaned: before, the `qgis_run_algorithm()` tests wrote various `qgis_process` output to the console, e.g.:

<details><summary><strong>Extract from previous <code>test_local()</code> output</strong> (click to expand)</summary>

```
✔ |        11 | qgis-output [7.3s]                                                             
✔ |        15 | qgis-result [1.8s]                                                             
⠴ |         6 | qgis-run-algorithm                                                             JSON input ----
{
  "inputs": {
    "INPUT": "/media/floris/DATA/git_repositories/qgisprocess/inst/longlake/longlake_depth.tif",
    "Z_FACTOR": 1,
    "AUTO_COLORS": false,
    "COLORS": "-0.5, 0, 170, 0, 0; 0, 0.5, 85, 255, 255; 0.5, 1, 0, 255, 0; 1, 2.5, 85, 85, 255",
    "OUTPUT": "/tmp/RtmpPWdFLe/file897853c70bce/file8978da944ee.tif",
    "FREQUENCY_DISTRIBUTION": "/tmp/RtmpPWdFLe/file897853c70bce/file89785eb1a797"
  }
}

Running qgis_process --json run 'qgis:relief' -

⠧ |         8 | qgis-run-algorithm                                                             JSON input ----
{
  "inputs": {
    "LAYOUT": "Layout 1",
    "TEXT_FORMAT": 0,
    "OUTPUT": "/tmp/RtmpPWdFLe/file897853c70bce/file89786124347e.pdf"
  },
  "project_path": "/media/floris/DATA/git_repositories/qgisprocess/inst/extdata/longlake.qgs"
}

```
</details>

and this has now gone.
- a lingering GPKG from testing is removed

Together, this results in below output of `test_local()` (in Linux Mint 20 ~ Ubuntu Focal).

<details><summary><strong>Current <code>test_local()</code> output</strong> (click to expand)</summary>

```r
> test_local()
Using 'qgis_process' in the system PATH.
QGIS version: 3.26.2-Buenos Aires
Configuration loaded from '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.
>>> If you need another installed QGIS version, run `qgis_configure()`;
    see its documentation if you need to preset the path of qgis_process.
- Using JSON for input serialization.
- Using JSON for output serialization.
✔ | F W S  OK | Context
✔ |        16 | compat-raster [7.1s]                                                                         
✔ |        23 | compat-sf [5.5s]                                                                             
✔ |         7 | compat-stars [0.2s]                                                                          
✔ |         9 | compat-terra [0.1s]                                                                          
✔ |         8 | qgis-algorithm                                                                               
✔ |        31 | qgis-arguments                                                                               
✔ |     1   6 | qgis-configure [6.4s]                                                                        
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Skip (test-qgis-configure.R:29:3): qgis_configure() returns FALSE with no QGIS
Reason: has_qgis() is TRUE
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ |         2 | qgis-detect                                                                                  
✔ |         8 | qgis-function [3.4s]                                                                         
✔ |     1  45 | qgis-help [0.5s]                                                                             
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Skip (test-qgis-help.R:55:3): qgis_arguments() and qgis_outputs() works for all algorithms
Reason: Test takes ~1 hr to run
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ |        11 | qgis-output [7.1s]                                                                           
✔ |        15 | qgis-result [1.8s]                                                                           
✔ |        13 | qgis-run-algorithm [10.5s]                                                                   
✔ |        14 | qgis-run-algorithm2 [10.4s]                                                                  
✔ |        13 | qgis-tmp                                                                                     

══ Results ══════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 53.3 s

── Skipped tests  ───────────────────────────────────────────────────────────────────────────────────────────
• has_qgis() is TRUE (1)
• Test takes ~1 hr to run (1)

[ FAIL 0 | WARN 0 | SKIP 2 | PASS 221 ]

MMM - ace code.
```
</details>
