### PR TITLE
Prepare switching default branch from master to main

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
 name: R-CMD-check
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![R build status](https://github.com/paleolimbot/qgisprocess/workflows/R-CMD-check/badge.svg)](https://github.com/paleolimbot/qgisprocess/actions)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
-[![Codecov test coverage](https://codecov.io/gh/paleolimbot/qgisprocess/branch/master/graph/badge.svg)](https://codecov.io/gh/paleolimbot/qgisprocess?branch=master)
+[![Codecov test coverage](https://codecov.io/gh/paleolimbot/qgisprocess/branch/main/graph/badge.svg)](https://codecov.io/gh/paleolimbot/qgisprocess?branch=main)
 <!-- badges: end -->
 
 The goal of `qgisprocess` is to provide an R interface to the popular and open source desktop geographic information system (GIS) program [QGIS](https://qgis.org/en/site/). The package is a re-implementation of functionality provided by the archived [RQGIS](https://cran.r-project.org/package=RQGIS) package, which was partially revived in the [RQGIS3](https://github.com/r-spatial/RQGIS3) package.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ status](https://github.com/paleolimbot/qgisprocess/workflows/R-CMD-check/badge.s
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 [![Codecov test
-coverage](https://codecov.io/gh/paleolimbot/qgisprocess/branch/master/graph/badge.svg)](https://codecov.io/gh/paleolimbot/qgisprocess?branch=master)
+coverage](https://codecov.io/gh/paleolimbot/qgisprocess/branch/main/graph/badge.svg)](https://codecov.io/gh/paleolimbot/qgisprocess?branch=main)
 <!-- badges: end -->
 
 The goal of `qgisprocess` is to provide an R interface to the popular


### PR DESCRIPTION
This replaces hardcoded references to `master` by `main`, or adds them, where needed. Fixes #113.

When default branch `main` is ready (renaming of `master`), base branch of this PR + PR #31 needs to be flipped too.

Alternative is to first merge this in `master`, then rename default as `main` in GH.