### PR TITLE
Enhance detection and representation of QGIS development versions

### DIFF
--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -11,6 +11,24 @@ test_that("qgis_query_version() works", {
   expect_match(qgis_query_version(), "^\\d{1,2}\\.\\d+.*-.+")
 })
 
+test_that("qgis_query_version() works for development versions of QGIS", {
+  skip_if_not(has_qgis())
+  qversion <- qgis_query_version()
+  skip_if_not(
+    stringr::str_detect(
+      qversion,
+      "^\\d{1,2}\\.\\d*[13579][\\.-]"
+    ),
+    paste("QGIS version", qversion, "is not a development version.")
+  )
+
+  expect_match(
+    qversion,
+    "^\\d{1,2}\\.\\d+.*-\\p{L}+, development state [0-9a-f]{8,}",
+    perl = TRUE
+  )
+})
+
 test_that("qgis_algorithms() works", {
   skip_if_not(has_qgis())
 


### PR DESCRIPTION
This PR extends the reported and cached QGIS version string with the corresponding commit hash from the QGIS code repository, on condition that a development version is in use. Consequently, the cache will be rebuilt when switching to another development version (commit hash) of QGIS.

Currently, the labelling with the commit hash is triggered by the label 'Master' or the fact that the 'minor' part of the version number is odd.

```r
> qgis_version()
[1] "3.28.1-Firenze"
> options(qgisprocess.path = "/home/floris/git_repositories2/QGIS/build2/output/bin/qgis_process")
> suppressMessages(qgis_configure())
> qgis_version()
[1] "3.29.0-Master, development state cfbf5ef5"
> options(qgisprocess.path = "/home/floris/git_repositories2/QGIS/build3/output/bin/qgis_process")
> suppressMessages(qgis_configure())
> qgis_version()
[1] "3.29.0-Master, development state 8d18f7c5"
> options(qgisprocess.path = "qgis_process")
> suppressMessages(qgis_configure())
> qgis_version()
[1] "3.28.1-Firenze"
```

<details><summary>The messages about triggering cache-rebuild are shown in the details below (click to expand).</summary>

```r
> options(qgisprocess.path = "/home/floris/git_repositories2/QGIS/build2/output/bin/qgis_process")
> devtools::load_all("~/git_repositories/qgisprocess")
ℹ Loading qgisprocess
Using 'qgis_process' at '/home/floris/git_repositories2/QGIS/build2/output/bin/qgis_process'.
QGIS version: 3.29.0-Master, development state cfbf5ef5
Configuration loaded from '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.
>>> If you need another installed QGIS version, run `qgis_configure()`;
    see its documentation if you need to preset the path of qgis_process.
- Using JSON for input serialization.
- Using JSON for output serialization.

Restarting R session...

> options(qgisprocess.path = "/home/floris/git_repositories2/QGIS/build3/output/bin/qgis_process")
> devtools::load_all("~/git_repositories/qgisprocess")
ℹ Loading qgisprocess
The user's qgisprocess.path option or the R_QGISPROCESS_PATH environment variable specify a different qgis_process path (/home/floris/git_repositories2/QGIS/build3/output/bin/qgis_process) than the cache did (/home/floris/git_repositories2/QGIS/build2/output/bin/qgis_process).
Hence rebuilding cache to reflect this change.
Using 'qgis_process' at '/home/floris/git_repositories2/QGIS/build3/output/bin/qgis_process'.
QGIS version: 3.29.0-Master, development state 8d18f7c5
Metadata of 784 algorithms successfully cached.
Run `qgis_algorithms()` to see them.
>>> If you need another installed QGIS version, run `qgis_configure()`;
    see its documentation if you need to preset the path of qgis_process.
- Using JSON for input serialization.
- Using JSON for output serialization.

Restarting R session...

> devtools::load_all("~/git_repositories/qgisprocess")
ℹ Loading qgisprocess
Using 'qgis_process' at '/home/floris/git_repositories2/QGIS/build3/output/bin/qgis_process'.
QGIS version: 3.29.0-Master, development state 8d18f7c5
Configuration loaded from '~/.cache/R-qgisprocess/cache-0.0.0.9000.rds'
Run `qgis_configure(use_cached_data = TRUE)` to reload cache and get more details.
>>> If you need another installed QGIS version, run `qgis_configure()`;
    see its documentation if you need to preset the path of qgis_process.
- Using JSON for input serialization.
- Using JSON for output serialization.

Restarting R session...

> options(qgisprocess.path = "qgis_process")
> devtools::load_all("~/git_repositories/qgisprocess")
ℹ Loading qgisprocess
The user's qgisprocess.path option or the R_QGISPROCESS_PATH environment variable specify a different qgis_process path (qgis_process) than the cache did (/home/floris/git_repositories2/QGIS/build3/output/bin/qgis_process).
Hence rebuilding cache to reflect this change.
Using 'qgis_process' in the system PATH.
QGIS version: 3.28.1-Firenze
Metadata of 1151 algorithms successfully cached.
Run `qgis_algorithms()` to see them.
>>> If you need another installed QGIS version, run `qgis_configure()`;
    see its documentation if you need to preset the path of qgis_process.
- Using JSON for input serialization.
- Using JSON for output serialization.
```

</details>

The above output uses Linux Mint 21 (Ubuntu 22.04), R 4.2.2, and QGIS 3.28.1 from ubuntugis-unstable PPA.