### PR TITLE
Various maintenance updates

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,8 +21,8 @@ jobs:
           - {os: macOS-latest, qgis: 'none', r: 'release'}
           - {os: macOS-latest, qgis: 'macos-brew', r: 'release'}
           - {os: windows-latest, qgis: 'windows-chocolatey', r: 'release'}
-          - {os: ubuntu-20.04, qgis: 'ubuntu-nightly', r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, qgis: 'ubuntu', r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, qgis: 'ubuntu-nightly', r: 'release'}
+          - {os: ubuntu-20.04, qgis: 'ubuntu', r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,8 +21,8 @@ jobs:
           - {os: macOS-latest, qgis: 'none', r: 'release'}
           - {os: macOS-latest, qgis: 'macos-brew', r: 'release'}
           - {os: windows-latest, qgis: 'windows-chocolatey', r: 'release'}
-          - {os: ubuntu-20.04, qgis: 'ubuntu-nightly', r: 'release'}
-          - {os: ubuntu-20.04, qgis: 'ubuntu', r: 'release'}
+          - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'release'}
+          - {os: ubuntu-22.04, qgis: 'ubuntu', r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install QGIS (Windows chocolatey)
         if: matrix.config.qgis == 'windows-chocolatey'
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install qgis
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,18 +47,16 @@ jobs:
       - name: Install QGIS (Ubuntu Nightly)
         if: matrix.config.qgis == 'ubuntu-nightly'
         run: |
-          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
-          sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
-          sudo add-apt-repository "deb https://qgis.org/ubuntu-nightly `lsb_release -c -s` main"
+          sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
 
       - name: Install QGIS (Ubuntu)
         if: matrix.config.qgis == 'ubuntu'
         run: |
-          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
-          sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
-          sudo add-apt-repository "deb https://qgis.org/ubuntu `lsb_release -c -s` main"
+          sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -85,10 +85,10 @@ jobs:
 
       # run with CMD check because installing QGIS is expensive
       - name: Test Coverage
-        if: matrix.config.qgis == 'macos-brew'
+        if: matrix.config.qgis == 'ubuntu'
         run: |
           install.packages("covr")
-          covr::codecov()
+          covr::codecov(quiet = FALSE)
         shell: Rscript {0}
 
       - name: Show testthat output
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-${{ matrix.config.qgis }}-results
           path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,7 @@ jobs:
           - {os: macOS-latest, qgis: 'macos-brew', r: 'release'}
           - {os: windows-latest, qgis: 'windows-chocolatey', r: 'release'}
           - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'release'}
+          - {os: ubuntu-22.04, qgis: 'ubuntugis', r: 'release'}
           - {os: ubuntu-22.04, qgis: 'ubuntu', r: 'release'}
 
     env:
@@ -44,7 +45,7 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Install QGIS (Ubuntu Nightly)
+      - name: Install QGIS (Ubuntu Nightly QGIS repo + possibly older GRASS from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu-nightly'
         run: |
           sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
@@ -52,7 +53,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
 
-      - name: Install QGIS (Ubuntu)
+      - name: Install QGIS (Ubuntugis QGIS repo + ubuntugis-unstable PPA, which has the current GRASS release)
+        if: matrix.config.qgis == 'ubuntugis'
+        run: |
+          sudo mkdir -p /root/.gnupg
+          sudo chmod 700 /root/.gnupg
+          sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/ubuntugis-unstable-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ubuntugis-unstable-archive-keyring.gpg] http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/ubuntugis-unstable.list'
+          sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntugis `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
+          sudo apt-get update
+          sudo apt-get install -y qgis qgis-plugin-grass saga
+
+      - name: Install QGIS (Ubuntu QGIS repo + possibly older GRASS from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu'
         run: |
           sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -105,5 +105,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-${{ matrix.config.qgis }}-results
+          name: ${{ matrix.config.os }}_r-${{ matrix.config.r }}_qgis-${{ matrix.config.qgis }}_results
           path: check

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,7 +11,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,6 +20,8 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - name: Install QGIS (Ubuntu)
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,11 +15,11 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-r@v2
 
       - name: Install QGIS (Ubuntu)
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,9 +25,8 @@ jobs:
 
       - name: Install QGIS (Ubuntu)
         run: |
-          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import || true
-          sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
-          sudo add-apt-repository "deb https://qgis.org/ubuntu `lsb_release -c -s` main"
+          sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,6 @@ Suggests:
     sf,
     raster,
     rgdal,
-    covr,
     stars,
     terra,
     fs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,5 @@ Suggests:
     raster,
     rgdal,
     stars,
-    terra,
-    fs
+    terra
 SystemRequirements: QGIS (>= 3.16). OSGeo4W is recommended for Windows users. 

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -166,7 +166,7 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
             "than the cache did ({cached_data$path})."))
         }
 
-        message("Hence rebuilding cache to reflect this change.")
+        message("Hence rebuilding cache to reflect this change ...")
       })
     }
 

--- a/tests/testthat/test-compat-raster.R
+++ b/tests/testthat/test-compat-raster.R
@@ -1,7 +1,6 @@
 
 test_that("raster argument coercers work", {
   skip_if_not_installed("raster")
-  skip_if_not_installed("rgdal")
 
   obj <- raster::raster()
   expect_error(
@@ -33,7 +32,6 @@ test_that("raster argument coercers work", {
 
 test_that("raster result coercers work", {
   skip_if_not_installed("raster")
-  skip_if_not_installed("rgdal")
 
   expect_is(
     qgis_as_raster(
@@ -122,7 +120,6 @@ test_that("raster crs work", {
 
 test_that("raster argument coercer for extent works", {
   skip_if_not_installed("raster")
-  skip_if_not_installed("rgdal")
 
   obj <- raster::raster(system.file("longlake/longlake.tif", package = "qgisprocess"))
 

--- a/tests/testthat/test-compat-raster.R
+++ b/tests/testthat/test-compat-raster.R
@@ -137,9 +137,6 @@ test_that("raster argument coercer for crs works", {
   skip_if_not_installed("rgdal")
   skip_if_not(has_qgis())
 
-  # Until Issue #36 is resolved (WKT2 as an argument causes a failure)
-  skip_on_os("windows")
-
   obj <- raster::raster(system.file("longlake/longlake.tif", package = "qgisprocess"))
 
   result <- qgis_run_algorithm(

--- a/tests/testthat/test-compat-stars.R
+++ b/tests/testthat/test-compat-stars.R
@@ -21,8 +21,8 @@ test_that("stars argument coercers work", {
     proxy = TRUE
   )
   expect_equal(
-    fs::path_abs(as_qgis_argument(obj, qgis_argument_spec(qgis_type = "layer"))),
-    fs::path_abs(system.file("longlake/longlake.tif", package = "qgisprocess"))
+    normalizePath(as_qgis_argument(obj, qgis_argument_spec(qgis_type = "layer"))),
+    normalizePath(system.file("longlake/longlake.tif", package = "qgisprocess"))
   )
 })
 

--- a/tests/testthat/test-qgis-result.R
+++ b/tests/testthat/test-qgis-result.R
@@ -7,7 +7,6 @@ test_that("qgis_output() works", {
 
 test_that("qgis_result_*() functions work", {
   skip_if_not(has_qgis())
-  skip_if_offline()
 
   tmp_gpkg <- qgis_tmp_vector(".gpkg")
   tmp_gpkg2 <- qgis_tmp_vector(".gpkg")

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -5,7 +5,6 @@ input <-
 
 test_that(glue("qgis_run_algorithm() works{input}"), {
   skip_if_not(has_qgis())
-  skip_if_offline()
 
   tmp_gpkg <- qgis_tmp_vector(".gpkg")
 

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -96,6 +96,7 @@ test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptab
 
 test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"), {
   skip_if_not(has_qgis())
+  # Until Issue #68 is resolved (native:printlayouttopdf segfaults on MacOS):
   skip_on_os("mac")
 
   tmp_pdf <- qgis_tmp_file(".pdf")


### PR DESCRIPTION
Mainly:

- drop some packages from `Suggests`: **covr** and **fs**. The first is installed explicitly in GH Actions and not used elsewhere, the second was used in just one test and has been replaced.
- tests: drop some `skip_*` statements from tests where it's unneeded; reactivate a Windows test.
  - This is also done in preparation of the retirement of **rgdal**, which is still in `Suggests` (currently still needed by `raster::crs` in two tests, but that should change in future since **raster** is scheduled to call **terra** instead of **rgdal** in such cases).
- update GHA workflows:
  - reflect updates in r-lib/actions
  - use latest Ubuntu LTS
  - more future-proof APT key management for the Ubuntu jobs, i.e. storing keys in `/etc/apt/keyrings` and referring accordingly (not doing this typically yields warnings; also `apt-key` is being deprecated in this context). See commit message 4dac770 for some links. The QGIS installation instructions were already updated in that sense. `add-apt-repository` can meet the requirements locally but for some reason [not in GHA](https://github.com/florisvdh/qgisprocess/actions/runs/3584657118/jobs/6031612888), so the repo definition file is written directly.
  - add a job that uses the Ubuntugis repo of QGIS + current instead of legacy GRASS release; the Ubuntugis repo is tailored to it.