### PR TITLE
qgis_query_version(): don't require the commit hash for regular releases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Imports: 
     processx (>= 3.5.2),
     stringr,

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -390,9 +390,11 @@ qgis_query_version <- function(quiet = FALSE) {
   match <- match[!is.na(match)]
   if (length(match) == 0L) abort_query_version(lines = lines)
   if (
-    stringr::str_detect(match[1], "[Mm]a(ster|in)") ||
-    stringr::str_detect(match[1], "^\\d{1,2}\\.\\d*[13579][\\.-]")
+    !stringr::str_detect(match[1], "[Mm]a(ster|in)") &&
+    !stringr::str_detect(match[1], "^\\d{1,2}\\.\\d*[13579][\\.-]")
   ) {
+    return(match[1])
+  } else {
     if (length(match) < 2L) abort_query_version(lines = lines)
     if (!stringr::str_detect(match[2], "[0-9a-f]{7,}")) {
       warning("Please consider building the QGIS development version from ",
@@ -406,8 +408,6 @@ qgis_query_version <- function(quiet = FALSE) {
       match[2] <- paste("unclear:", match[2])
     }
     return(paste0(match[1], ", development state ", match[2]))
-  } else {
-    return(match[1])
   }
 }
 

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -390,13 +390,13 @@ qgis_query_version <- function(quiet = FALSE) {
   match <- match[!is.na(match)]
   if (length(match) == 0L) abort_query_version(lines = lines)
   if (
-    !stringr::str_detect(match[1], "[Mm]a(ster|in)") &&
+    !stringr::str_detect(match[1], "-[Mm]a(ster|in)$") &&
     !stringr::str_detect(match[1], "^\\d{1,2}\\.\\d*[13579][\\.-]")
   ) {
     return(match[1])
   } else {
     if (length(match) < 2L) abort_query_version(lines = lines)
-    if (!stringr::str_detect(match[2], "[0-9a-f]{7,}")) {
+    if (!stringr::str_detect(match[2], "^[0-9a-f]{7,}$")) {
       warning("Please consider building the QGIS development version from ",
               "within the QGIS git repository, in order to have a unique ",
               "version identier of QGIS, or propose the people making the ",

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -385,7 +385,7 @@ qgis_query_version <- function(quiet = FALSE) {
   lines <- readLines(textConnection(result$stdout))
   match <- stringr::str_match(
     lines,
-    "QGIS\\s(\\d{1,2}\\.\\d+.*-\\p{L}+)\\s.*\\(([0-9a-f]{8,})\\)"
+    "QGIS\\s(\\d{1,2}\\.\\d+.*-\\p{L}+)\\s.*\\((\\w+)\\)"
   )[, 2:3, drop = TRUE]
   match <- match[!is.na(match)]
   if (length(match) == 0L) abort_query_version(lines = lines)

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -390,7 +390,7 @@ qgis_query_version <- function(quiet = FALSE) {
   match <- match[!is.na(match)]
   if (length(match) == 0L) abort_query_version(lines = lines)
   if (
-    stringr::str_detect(match[1], "[Mm]aster") ||
+    stringr::str_detect(match[1], "[Mm]a(ster|in)") ||
     stringr::str_detect(match[1], "^\\d{1,2}\\.\\d*[13579][\\.-]")
   ) {
     if (length(match) < 2L) abort_query_version(lines = lines)

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -399,7 +399,7 @@ qgis_query_version <- function(quiet = FALSE) {
     if (!stringr::str_detect(match[2], "^[0-9a-f]{7,}$")) {
       warning("Please consider building the QGIS development version from ",
               "within the QGIS git repository, in order to have a unique ",
-              "version identier of QGIS, or propose the people making the ",
+              "version identifier of QGIS, or propose the people making the ",
               "QGIS build to do so. ",
               "Currently the specific version identifier is '",
               match[2],

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -394,6 +394,17 @@ qgis_query_version <- function(quiet = FALSE) {
     stringr::str_detect(match[1], "^\\d{1,2}\\.\\d*[13579][\\.-]")
   ) {
     if (length(match) < 2L) abort_query_version(lines = lines)
+    if (!stringr::str_detect(match[2], "[0-9a-f]{7,}")) {
+      warning("Please consider building the QGIS development version from ",
+              "within the QGIS git repository, in order to have a unique ",
+              "version identier of QGIS, or propose the people making the ",
+              "QGIS build to do so. ",
+              "Currently the specific version identifier is '",
+              match[2],
+              "'.",
+              call. = TRUE)
+      match[2] <- paste("unclear:", match[2])
+    }
     return(paste0(match[1], ", development state ", match[2]))
   } else {
     return(match[1])

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -385,7 +385,7 @@ qgis_query_version <- function(quiet = FALSE) {
   lines <- readLines(textConnection(result$stdout))
   match <- stringr::str_match(
     lines,
-    "QGIS\\s(\\d{1,2}\\.\\d+.*-\\p{L}+)\\s.*\\((\\w+)\\)"
+    "QGIS\\s(\\d{1,2}\\.\\d+.*-\\p{L}+)\\s.*\\((.+)\\)"
   )[, 2:3, drop = TRUE]
   match <- match[!is.na(match)]
   if (length(match) == 0L) abort_query_version(lines = lines)

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -27,6 +27,10 @@ test_that("qgis_query_version() works for development versions of QGIS", {
     "^\\d{1,2}\\.\\d+.*-\\p{L}+, development state ([0-9a-f]{7,}|unclear:.+)",
     perl = TRUE
   )
+
+  if (stringr::str_detect(qversion, ".+development state unclear:.+")) {
+    expect_warning(qgis_query_version(), "version identier")
+  }
 })
 
 test_that("qgis_algorithms() works", {

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -24,7 +24,7 @@ test_that("qgis_query_version() works for development versions of QGIS", {
 
   expect_match(
     qversion,
-    "^\\d{1,2}\\.\\d+.*-\\p{L}+, development state [0-9a-f]{8,}",
+    "^\\d{1,2}\\.\\d+.*-\\p{L}+, development state ([0-9a-f]{7,}|unclear:.+)",
     perl = TRUE
   )
 })

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -29,7 +29,7 @@ test_that("qgis_query_version() works for development versions of QGIS", {
   )
 
   if (stringr::str_detect(qversion, ".+development state unclear:.+")) {
-    expect_warning(qgis_query_version(), "version identier")
+    expect_warning(qgis_query_version(), "version identifier")
   }
 })
 


### PR DESCRIPTION
Fixes #117; follow-up for #115.

Now the presence of a commit hash is only verified in QGIS dev versions.

For QGIS dev versions with _no_ commit hash advertised (i.e. [if not built from a git repo context](https://github.com/qgis/QGIS/blob/d13a7b72787b5557860a38cdceda482a9dd4831e/cmake/CreateQgsVersion.cmake#L50)), a warning is issued and the version string will become e.g.:

`3.29.0-Master, development state unclear: exported`

Meanwhile, I noticed a segfault for the `native:printlayouttopdf` test in Linux Mint 21.1 (Ubuntu 22.04), when checking the package locally, possibly triggered by upgrading QGIS to 3.28.2. The segfault seems to occur after successfully doing the job though. `qgis_process` also throws a weird message 'Problem with SAGA installation: unsupported SAGA version (found: 8.2.2, required: 2.3.).'.  Perhaps this is something going on just here, let's see what the GHA workflows say. _Update wrt SAGA: 'unsupported'  may make sense, since SAGA was recently updated to 8.2.2 (ubuntugis-unstable PPA) which is probably too high for QGIS 3.28.2; QGIS dev version doesn't complain anymore about that._
