### PR TITLE
Fixes in GitHub actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Install missing package dependencies
         run: |
+          # Install missing package dependencies
           cat("::group::Install\n")
           pak::pkg_install(c("deps::.", "any::sessioninfo", "any::rcmdcheck"), upgrade = FALSE, dependencies = c("Config/Needs/check", "all"))
           # This is based on the minimum needed version, not the hash of what is available at RSPM
@@ -136,10 +137,10 @@ jobs:
         shell: Rscript {0}
 
       # raster, sf, terra, lwgeom and rgdal from RSPM use older sysdeps than ubuntugis
-      - name: In the ubuntugis job, reinstall some pkgs from source
+      - name: In the ubuntugis job, reinstall some pkgs from source if needed
         if: matrix.config.qgis == 'ubuntugis'
         run: |
-          # Rebuild and install sf, terra etc. from source if the RSPM binaries don't load
+          # Rebuild and install sf, terra etc. if the RSPM binaries (or cached pkgs) don't load
           cat("::group::sf\n")
           if (!requireNamespace("sf", quietly = TRUE)) {
             install.packages("sf", repos = "https://cloud.r-project.org")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -100,7 +100,7 @@ jobs:
         run: |
           # Query R dependencies and report available versions
           cat("::group::Install pak\n")
-          install.packages("pak")
+          install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
           cat("::endgroup::\n")
           cat("::group::Create minimal data frame with pkg deps and store them\n")
           depends <- pak::pkg_deps(c("deps::.", "any::sessioninfo", "any::rcmdcheck"), dependencies = c("Config/Needs/check", "all"))[, c("ref", "version")]

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -95,11 +95,28 @@ jobs:
         with:
           args: install qgis
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - name: Query R dependencies based on available versions
+        run: |
+          install.packages("pak")
+          depends <- pak::pkg_deps(c("deps::.", "any::sessioninfo", "any::rcmdcheck"), dependencies = c("Config/Needs/check", "all"))[, c("ref", "version")]
+          depends <- depends[depends$ref != "deps::.", ]
+          saveRDS(depends, ".github/depends.Rds")
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Restore (or define new) R package cache
+        uses: actions/cache@v3
         with:
-          extra-packages: any::rcmdcheck
-          needs: check
-          cache-version: ${{ matrix.config.r-pkg-cache }}
+          path: |
+            ${{ env.R_LIBS_USER }}/*
+            !${{ env.R_LIBS_USER }}/pak
+          key: ${{ matrix.config.os }}-${{ matrix.config.r-pkg-cache }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+
+      - name: Install missing package dependencies
+        run: |
+          pak::pkg_install(c("deps::.", "any::sessioninfo", "any::rcmdcheck"), upgrade = FALSE, dependencies = c("Config/Needs/check", "all"))
+          # This is based on the minimum needed version, not the hash of what is available at RSPM
+        shell: Rscript {0}
 
       # raster, sf, terra, lwgeom and rgdal from RSPM use older sysdeps than ubuntugis
       - name: In the ubuntugis job, reinstall some pkgs from source

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,7 +51,7 @@ jobs:
         if: matrix.config.qgis == 'ubuntu-nightly'
         run: |
           sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
-          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
+          sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu-nightly `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
           sudo apt-get install -y qgis qgis-plugin-grass saga
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,12 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest, qgis: 'none', r: 'release'}
-          - {os: macOS-latest, qgis: 'macos-brew', r: 'release'}
-          - {os: windows-latest, qgis: 'windows-chocolatey', r: 'release'}
-          - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'release'}
-          - {os: ubuntu-22.04, qgis: 'ubuntugis', r: 'release'}
-          - {os: ubuntu-22.04, qgis: 'ubuntu', r: 'release'}
+          - {os: macOS-latest, qgis: 'none', r: 'release', r-pkg-cache: 'v0'}
+          - {os: macOS-latest, qgis: 'macos-brew', r: 'release', r-pkg-cache: 'v0'}
+          - {os: windows-latest, qgis: 'windows-chocolatey', r: 'release', r-pkg-cache: 'v0'}
+          - {os: ubuntu-22.04, qgis: 'ubuntu-nightly', r: 'release', r-pkg-cache: 'v0'}
+          - {os: ubuntu-22.04, qgis: 'ubuntugis', r: 'release', r-pkg-cache: 'v1'}
+          - {os: ubuntu-22.04, qgis: 'ubuntu', r: 'release', r-pkg-cache: 'v0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +95,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          cache-version: ${{ matrix.config.r-pkg-cache }}
 
       # raster, sf, terra, lwgeom and rgdal from RSPM use older sysdeps than ubuntugis
       - name: In the ubuntugis job, reinstall some pkgs from source

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -95,13 +95,25 @@ jobs:
         with:
           args: install qgis
 
-      - name: Query R dependencies based on available versions
+      - name: Query R dependencies and report available versions
+        id: query
         run: |
+          # Query R dependencies and report available versions
+          cat("::group::Install pak\n")
           install.packages("pak")
+          cat("::endgroup::\n")
+          cat("::group::Create minimal data frame with pkg deps and store them\n")
           depends <- pak::pkg_deps(c("deps::.", "any::sessioninfo", "any::rcmdcheck"), dependencies = c("Config/Needs/check", "all"))[, c("ref", "version")]
           depends <- depends[depends$ref != "deps::.", ]
           saveRDS(depends, ".github/depends.Rds")
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+          cat("::endgroup::\n")
+          cat("::group::Store R-version\n")
+          cat("r-version=", sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+          cat("::endgroup::\n")
+          cat("::group::Print results\n")
+          cat("R version:", sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), "\n")
+          print(as.data.frame(depends), row.names = FALSE)
+          cat("::endgroup::\n")
         shell: Rscript {0}
 
       - name: Restore (or define new) R package cache
@@ -110,12 +122,17 @@ jobs:
           path: |
             ${{ env.R_LIBS_USER }}/*
             !${{ env.R_LIBS_USER }}/pak
-          key: ${{ matrix.config.os }}-${{ matrix.config.r-pkg-cache }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          key: ${{ matrix.config.os }}-${{ steps.query.outputs.r-version }}-${{ matrix.config.r-pkg-cache }}-${{ hashFiles('.github/depends.Rds') }}
 
       - name: Install missing package dependencies
         run: |
+          cat("::group::Install\n")
           pak::pkg_install(c("deps::.", "any::sessioninfo", "any::rcmdcheck"), upgrade = FALSE, dependencies = c("Config/Needs/check", "all"))
           # This is based on the minimum needed version, not the hash of what is available at RSPM
+          cat("::endgroup::\n")
+          cat("::group::Session info\n")
+          sessioninfo::session_info(pkgs = "installed", include_base = TRUE)
+          cat("::endgroup::\n")
         shell: Rscript {0}
 
       # raster, sf, terra, lwgeom and rgdal from RSPM use older sysdeps than ubuntugis

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -101,19 +101,29 @@ jobs:
       - name: In the ubuntugis job, reinstall some pkgs from source
         if: matrix.config.qgis == 'ubuntugis'
         run: |
+          cat("::group::sf\n")
           if (!requireNamespace("sf", quietly = TRUE)) {
             install.packages("sf", repos = "https://cloud.r-project.org")
           }
+          cat("::endgroup::\n")
+          cat("::group::terra\n")
           if (!requireNamespace("terra", quietly = TRUE)) {
             install.packages("terra", repos = "https://cloud.r-project.org")
           }
+          cat("::endgroup::\n")
+          cat("::group::raster and rgdal (rgdal still needed)\n")
           if (!requireNamespace("raster", quietly = TRUE)) {  # rgdal: temporarily
             install.packages(c("rgdal", "raster"), repos = "https://cloud.r-project.org")
           }
+          cat("::endgroup::\n")
+          cat("::group::lwgeom (needed by stars)\n")
           if (!requireNamespace("lwgeom", quietly = TRUE)) {  # needed for stars
             install.packages("lwgeom", repos = "https://cloud.r-project.org")
           }
+          cat("::endgroup::\n")
+          cat("::group::Session info\n")
           sessioninfo::session_info(pkgs = "installed", include_base = TRUE)
+          cat("::endgroup::\n")
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -100,7 +100,18 @@ jobs:
       - name: In the ubuntugis job, reinstall some pkgs from source
         if: matrix.config.qgis == 'ubuntugis'
         run: |
-          install.packages(c("raster", "sf", "terra", "lwgeom", "rgdal"), repos = "https://cloud.r-project.org")
+          if (!requireNamespace("sf", quietly = TRUE)) {
+            install.packages("sf", repos = "https://cloud.r-project.org")
+          }
+          if (!requireNamespace("terra", quietly = TRUE)) {
+            install.packages("terra", repos = "https://cloud.r-project.org")
+          }
+          if (!requireNamespace("raster", quietly = TRUE)) {  # rgdal: temporarily
+            install.packages(c("rgdal", "raster"), repos = "https://cloud.r-project.org")
+          }
+          if (!requireNamespace("lwgeom", quietly = TRUE)) {  # needed for stars
+            install.packages("lwgeom", repos = "https://cloud.r-project.org")
+          }
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,11 +42,6 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
-
       - name: Install QGIS (Ubuntu Nightly QGIS repo + possibly older GRASS from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu-nightly'
         run: |
@@ -95,6 +90,11 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install qgis
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
 
       - uses: r-lib/actions/check-r-package@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -96,6 +96,13 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      # raster, sf, terra, lwgeom and rgdal from RSPM use older sysdeps than ubuntugis
+      - name: In the ubuntugis job, reinstall some pkgs from source
+        if: matrix.config.qgis == 'ubuntugis'
+        run: |
+          install.packages(c("raster", "sf", "terra", "lwgeom", "rgdal"), repos = "https://cloud.r-project.org")
+        shell: Rscript {0}
+
       - uses: r-lib/actions/check-r-package@v2
 
       # run with CMD check because installing QGIS is expensive

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,6 +45,7 @@ jobs:
       - name: Install QGIS (Ubuntu Nightly QGIS repo + possibly older GRASS from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu-nightly'
         run: |
+          # Setup QGIS from Ubuntu Nightly
           sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu-nightly `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
@@ -53,6 +54,7 @@ jobs:
       - name: Install QGIS (Ubuntugis QGIS repo + ubuntugis-unstable PPA, which has the current GRASS release)
         if: matrix.config.qgis == 'ubuntugis'
         run: |
+          # Setup QGIS from Ubuntugis
           sudo mkdir -p /root/.gnupg
           sudo chmod 700 /root/.gnupg
           sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/ubuntugis-unstable-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
@@ -65,6 +67,7 @@ jobs:
       - name: Install QGIS (Ubuntu QGIS repo + possibly older GRASS from Ubuntu repo)
         if: matrix.config.qgis == 'ubuntu'
         run: |
+          # Setup QGIS from Ubuntu
           sudo wget -qO /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
           sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/ubuntu `lsb_release -c -s` main" > /etc/apt/sources.list.d/qgis.list'
           sudo apt-get update
@@ -81,6 +84,7 @@ jobs:
       - name: Install QGIS (MacOS nightly)
         if: matrix.config.qgis == 'macos-nightly'
         run: |
+          # Setup QGIS from MacOS nightly
           curl https://qgis.org/downloads/macos/qgis-macos-nightly.dmg --output qgis-macos-nightly.dmg
           yes | hdiutil attach -nobrowse -noverify -mountpoint qgis qgis-macos-nightly.dmg > /dev/null
           sudo cp -R qgis/QGIS.app /Applications
@@ -101,6 +105,7 @@ jobs:
       - name: In the ubuntugis job, reinstall some pkgs from source
         if: matrix.config.qgis == 'ubuntugis'
         run: |
+          # Rebuild and install sf, terra etc. from source if the RSPM binaries don't load
           cat("::group::sf\n")
           if (!requireNamespace("sf", quietly = TRUE)) {
             install.packages("sf", repos = "https://cloud.r-project.org")
@@ -132,6 +137,7 @@ jobs:
       - name: Test Coverage
         if: matrix.config.qgis == 'ubuntu'
         run: |
+          # Setup code coverage with Codecov
           install.packages("covr")
           covr::codecov(quiet = FALSE)
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -112,6 +112,7 @@ jobs:
           if (!requireNamespace("lwgeom", quietly = TRUE)) {  # needed for stars
             install.packages("lwgeom", repos = "https://cloud.r-project.org")
           }
+          sessioninfo::session_info(pkgs = "installed", include_base = TRUE)
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -102,7 +102,7 @@ test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"
   # see https://github.com/qgis/QGIS/issues/51383
   qversion <- qgis_version()
   skip_if(
-    stringr::str_detect(qversion, "^3.28.2-|^3.29"),
+    stringr::str_detect(qversion, "^3\\.28\\.2-|^3\\.29"),
     paste(
       "QGIS version",
       qversion,

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -107,8 +107,8 @@ test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"
       "QGIS version",
       qversion,
       "is reported to segfault with 'native:printlayouttopdf'."
-      )
     )
+  )
 
   tmp_pdf <- qgis_tmp_file(".pdf")
 

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -98,6 +98,17 @@ test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"
   skip_if_not(has_qgis())
   # Until Issue #68 is resolved (native:printlayouttopdf segfaults on MacOS):
   skip_on_os("mac")
+  # QGIS 3.28.2 and a series of QGIS 3.29.0 builds always segfault
+  # see https://github.com/qgis/QGIS/issues/51383
+  qversion <- qgis_version()
+  skip_if(
+    stringr::str_detect(qversion, "^3.28.2-|^3.29"),
+    paste(
+      "QGIS version",
+      qversion,
+      "is reported to segfault with 'native:printlayouttopdf'."
+      )
+    )
 
   tmp_pdf <- qgis_tmp_file(".pdf")
 


### PR DESCRIPTION
This PR addresses several problems described in https://github.com/paleolimbot/qgisprocess/pull/118#issuecomment-1371305999.

- `ubuntu-nightly` job: fixed a regression in the repo URL (introduced in PR #116)
- skip the `native:printlayouttopdf` test for QGIS 3.28.2 (segfaults in each OS where this is not skipped). This problem is being / has been addressed at QGIS (https://github.com/qgis/QGIS/issues/51383). For the time being, also 3.29 is skipped, to be revisited soon.
- fix the QGIS installation problem in the `ubuntugis` job. This has been solved by a general (cross-job) change, i.e. postponing R pkg dep installations until QGIS is installed.
  - That is because the `ubuntugis` job involves adding another repo with more recent GDAL and PROJ.
  - If not postponing, R pkg installation triggered installation of older PROJ/GDAL before the PPA addition, which made the ubuntugis-QGIS 3.28.2 (but not 3.28.1) installation fail ([segfault](https://github.com/paleolimbot/qgisprocess/actions/runs/3853905961/jobs/6567346051#step:7:681) during setting up `qgis-providers`).
  - Moreover, this now required recompiling some R packages used in the tests (**raster**, **terra**, **lwgeom**, **sf**, **rgdal**) against these more recent GDAL/PROJ versions (since that's _currently_ not the case in RSPM-versions). That didn't work with `pak::pkg_install("cran::xxx")`, so using `install.packages()`.
    - This package recompilation is quite expensive (sequentially building 5 packages takes ± 10-15 min); the `ubuntugis` job can therefore take as long as the `macos-brew` job. In b633f55 this has been relaxed for the packages that do load successfully without recompilation (none at this time); it all depends on the state of RSPM versus the ubuntugis-unstable PPA and so the need for recompilation is not constant in time.