### PR TITLE
GHA R-CMD-check: run weekly?

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - master
       - main
+  schedule:
+    - cron:  '0 3 * * 4'
 
 name: R-CMD-check
 


### PR DESCRIPTION
@paleolimbot I propose to run `R-CMD-check` on a weekly basis, in order to capture regressions in or incompatibilities with new QGIS releases and dev versions (the latter only in Ubuntu). What do you think?

It might be sufficient to do this only for the Ubuntu-nightly job, and apply a lower freq to the releases, but I didn't find how to differentiate scheduling between matrix configs in a simple way (it might be done by putting all steps into a reusable workflow and splitting the matrix over two caller workflows, each with another schedule => 3 instead of 1 workflow file). Further, for the releases on the three platforms it could be argued that it's difficult to predict the availability of new QGIS-packages cron-wise, given the release roadmap with some built-in irregular time steps, and some delay by the packagers – an argument to include releases in a weekly check.