### PR TITLE
test-qgis-run-algorithm.R: don't skip QGIS 3.29 anymore

### DIFF
--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -98,11 +98,11 @@ test_that(glue("qgis_run_algorithm succeeds when it needs a QGIS project{input}"
   skip_if_not(has_qgis())
   # Until Issue #68 is resolved (native:printlayouttopdf segfaults on MacOS):
   skip_on_os("mac")
-  # QGIS 3.28.2 and a series of QGIS 3.29.0 builds always segfault
+  # QGIS 3.28.2 (and a series of QGIS 3.29 builds) always segfault
   # see https://github.com/qgis/QGIS/issues/51383
   qversion <- qgis_version()
   skip_if(
-    stringr::str_detect(qversion, "^3\\.28\\.2-|^3\\.29"),
+    stringr::str_detect(qversion, "^3\\.28\\.2-"),
     paste(
       "QGIS version",
       qversion,


### PR DESCRIPTION
From https://github.com/paleolimbot/qgisprocess/pull/118#issuecomment-1371305999:

 > QGIS 3.28.2 and the Ubuntu-nightly (*) QGIS version consistently segfault with `native:printlayouttopdf`

https://github.com/qgis/QGIS/issues/51383 has been solved and the QGIS Ubuntu-nightly build now contains the fix, hence the issue is gone in QGIS 3.29.