### PR TITLE
Massive code styling by styler::style_pkg(...)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,9 +6,6 @@ on:
       - master
       - main
   pull_request:
-    branches:
-      - master
-      - main
   schedule:
     - cron:  '0 3 * * 4'
 

--- a/R/compat-raster.R
+++ b/R/compat-raster.R
@@ -1,4 +1,3 @@
-
 #' Convert raster objects to/from QGIS inputs/outputs
 #'
 #' @param x A [raster::raster()] or [raster::brick()].

--- a/R/compat-sf.R
+++ b/R/compat-sf.R
@@ -1,4 +1,3 @@
-
 #' Convert sf objects to/from QGIS inputs/outputs
 #'
 #' @inheritParams as_qgis_argument
@@ -21,7 +20,6 @@ as_qgis_argument.sf <- function(x, spec = qgis_argument_spec(),
 
 # dynamically registered in zzz.R
 st_as_sf.qgis_result <- function(x, ...) {
-
   result <- qgis_result_single(x, c("qgis_outputVector", "qgis_outputLayer"))
 
   if (grepl("\\|layer", result)) {
@@ -30,7 +28,6 @@ st_as_sf.qgis_result <- function(x, ...) {
   } else {
     sf::read_sf(result, ...)
   }
-
 }
 
 
@@ -65,7 +62,6 @@ as_qgis_argument.bbox <- function(x, spec = qgis_argument_spec(),
 #' @export
 as_qgis_argument.sfc <- function(x, spec = qgis_argument_spec(),
                                  use_json_input = FALSE) {
-
   if (!isTRUE(spec$qgis_type %in% c("point"))) {
     abort(glue("Can't convert 'sfc' object to QGIS type '{ spec$qgis_type }'"))
   }
@@ -89,7 +85,6 @@ as_qgis_argument.sfc <- function(x, spec = qgis_argument_spec(),
 #' @export
 as_qgis_argument.POINT <- function(x, spec = qgis_argument_spec(),
                                    use_json_input = FALSE) {
-
   if (!isTRUE(spec$qgis_type %in% c("point"))) {
     abort(glue("Can't convert 'POINT' object to QGIS type '{ spec$qgis_type }'"))
   }

--- a/R/compat-sf.R
+++ b/R/compat-sf.R
@@ -11,7 +11,7 @@ as_qgis_argument.sf <- function(x, spec = qgis_argument_spec(),
   }
 
   if (spec$qgis_type == "point") {
-    as_qgis_argument(sf::st_geometry(x), spec=spec)
+    as_qgis_argument(sf::st_geometry(x), spec = spec)
   } else {
     path <- qgis_tmp_vector()
     sf::write_sf(x, path)
@@ -54,9 +54,9 @@ as_qgis_argument.bbox <- function(x, spec = qgis_argument_spec(),
     abort(glue("Can't convert 'bbox' object to QGIS type '{ spec$qgis_type }'"))
   }
 
-  if (!is.na(sf::st_crs(x)$epsg)){
+  if (!is.na(sf::st_crs(x)$epsg)) {
     glue("{x$xmin},{x$xmax},{x$ymin},{x$ymax}[EPSG:{sf::st_crs(x)$epsg}]")
-  }else{
+  } else {
     glue("{x$xmin},{x$xmax},{x$ymin},{x$ymax}")
   }
 }
@@ -70,17 +70,17 @@ as_qgis_argument.sfc <- function(x, spec = qgis_argument_spec(),
     abort(glue("Can't convert 'sfc' object to QGIS type '{ spec$qgis_type }'"))
   }
 
-  if (isTRUE(length(x) != 1)){
+  if (isTRUE(length(x) != 1)) {
     abort(glue("Can't convert 'sfc' object to QGIS type '{ spec$qgis_type }' as the length is not equal to 1"))
   }
 
-  if (isTRUE((sf::st_geometry_type(x) != "POINT"))){
+  if (isTRUE((sf::st_geometry_type(x) != "POINT"))) {
     abort(glue("Can't convert 'sfc' object to QGIS type '{ spec$qgis_type }' as type is not 'POINT'"))
   }
 
-  if (!is.na(sf::st_crs(x)$epsg)){
+  if (!is.na(sf::st_crs(x)$epsg)) {
     glue("{x[[1]][1]},{x[[1]][2]}[EPSG:{sf::st_crs(x)$epsg}]")
-  }else{
+  } else {
     glue("{x[[1]][1]},{x[[1]][2]}")
   }
 }

--- a/R/compat-stars.R
+++ b/R/compat-stars.R
@@ -52,4 +52,3 @@ st_as_stars.qgis_result <- function(output, ...) {
   result <- qgis_result_single(output, c("qgis_outputRaster", "qgis_outputLayer"))
   stars::read_stars(unclass(result), ...)
 }
-

--- a/R/compat-stars.R
+++ b/R/compat-stars.R
@@ -1,4 +1,3 @@
-
 #' Convert raster objects to/from QGIS inputs/outputs
 #'
 #' @param x A stars or stars_proxy object.

--- a/R/compat-terra.R
+++ b/R/compat-terra.R
@@ -1,4 +1,3 @@
-
 #' Convert raster objects to/from QGIS inputs/outputs
 #'
 #' @param x A [terra::rast()].

--- a/R/qgis-algorithm.R
+++ b/R/qgis-algorithm.R
@@ -109,7 +109,7 @@ qgis_query_algorithms <- function(quiet = FALSE) {
       p_tbl
     })
 
-    providers <- vctrs::vec_rbind(!!! providers, .ptype = providers_ptype, .names_to = "provider_id")
+    providers <- vctrs::vec_rbind(!!!providers, .ptype = providers_ptype, .names_to = "provider_id")
 
     fields_ptype <- tibble::tibble(
       can_cancel = logical(),
@@ -137,11 +137,11 @@ qgis_query_algorithms <- function(quiet = FALSE) {
         alg_tbl
       })
 
-      vctrs::vec_rbind(!!! algs_p, ptype = fields_ptype, .names_to = "algorithm")
+      vctrs::vec_rbind(!!!algs_p, ptype = fields_ptype, .names_to = "algorithm")
     })
 
     fields_ptype$algorithm <- character()
-    algs <- vctrs::vec_rbind(!!! algs, ptype = fields_ptype, .names_to = "provider_id")
+    algs <- vctrs::vec_rbind(!!!algs, ptype = fields_ptype, .names_to = "provider_id")
     algs <- vctrs::vec_cbind(
       algs,
       providers[match(algs$provider_id, providers$provider_id), setdiff(names(providers), "provider_id")]
@@ -186,4 +186,3 @@ qgis_query_algorithms <- function(quiet = FALSE) {
     algorithms[!is.na(algorithms$algorithm_id), ]
   }
 }
-

--- a/R/qgis-arguments.R
+++ b/R/qgis-arguments.R
@@ -1,4 +1,3 @@
-
 #' Type coercion for arguments to QGIS processing algorithms
 #'
 #' Calls to [qgis_run_algorithm()] can and should contain R objects that
@@ -205,25 +204,20 @@ as_qgis_argument.qgis_default_value <- function(x, spec = qgis_argument_spec(),
   if (isTRUE(spec$qgis_type %in% c("sink", "vectorDestination"))) {
     message(glue("Using `{ spec$name } = qgis_tmp_vector()`"))
     qgis_tmp_vector()
-
   } else if (isTRUE(spec$qgis_type == "rasterDestination")) {
     message(glue("Using `{ spec$name } = qgis_tmp_raster()`"))
     qgis_tmp_raster()
-
   } else if (isTRUE(spec$qgis_type == "folderDestination")) {
     message(glue("Using `{ spec$name } = qgis_tmp_folder()`"))
     qgis_tmp_folder()
-
   } else if (isTRUE(spec$qgis_type == "fileDestination")) {
     # these are various types of files (pdf, raster stats, etc.)
     message(glue("Using `{ spec$name } = qgis_tmp_file(\"\")`"))
     qgis_tmp_file("")
-
   } else if (isTRUE(spec$qgis_type == "enum") && length(spec$available_values) > 0) {
     default_enum_value <- rlang::as_label(spec$available_values[1])
     message(glue("Using `{ spec$name } = { default_enum_value }`"))
     if (use_json_input) 0 else "0"
-
   } else {
     # We don't know the actual default values here as far as I can tell
     message(glue("Argument `{ spec$name }` is unspecified (using QGIS default value)."))
@@ -246,8 +240,7 @@ as_qgis_argument.NULL <- function(x, spec = qgis_argument_spec(),
 #' @export
 as_qgis_argument.character <- function(x, spec = qgis_argument_spec(),
                                        use_json_input = FALSE) {
-  result <- switch(
-    as.character(spec$qgis_type),
+  result <- switch(as.character(spec$qgis_type),
     field = if (use_json_input) x else paste0(x, collapse = ";"),
     enum = {
       x_int <- match(x, spec$available_values)
@@ -259,7 +252,8 @@ as_qgis_argument.character <- function(x, spec = qgis_argument_spec(),
             glue("All values for input '{ spec$name }' must be one of the following:\n\n"),
             glue::glue_collapse(
               paste0('"', spec$available_values, '"'),
-              ", ", last = " or "
+              ", ",
+              last = " or "
             )
           )
         )

--- a/R/qgis-arguments.R
+++ b/R/qgis-arguments.R
@@ -44,13 +44,13 @@ qgis_sanitize_arguments <- function(algorithm, ..., .algorithm_arguments = qgis_
   user_args[regular_dot_names] <- dots[regular_dot_names]
   for (arg_name in duplicated_dot_names) {
     items <- unname(dots[dot_names == arg_name])
-    user_args[[arg_name]] <- qgis_list_input(!!! items)
+    user_args[[arg_name]] <- qgis_list_input(!!!items)
   }
 
   # warn about unspecified arguments (don't error so that users can
   # write code for more than one QGIS install if args are added)
   unknown_args <- setdiff(names(dots), c("PROJECT_PATH", "ELLIPSOID", arg_meta$name))
-  if (length(unknown_args) > 0){
+  if (length(unknown_args) > 0) {
     for (arg_name in unknown_args) {
       message(glue("Ignoring unknown input '{ arg_name }'"))
     }
@@ -397,13 +397,13 @@ qgis_dict_input <- function(...) {
 #' @export
 as_qgis_argument.qgis_list_input <- function(x, spec = qgis_argument_spec(),
                                              use_json_input = FALSE) {
-  qgis_list_input(!!! lapply(x, as_qgis_argument, spec = spec, use_json_input = use_json_input))
+  qgis_list_input(!!!lapply(x, as_qgis_argument, spec = spec, use_json_input = use_json_input))
 }
 
 #' @export
 as_qgis_argument.qgis_dict_input <- function(x, spec = qgis_argument_spec(),
                                              use_json_input = FALSE) {
-  qgis_dict_input(!!! lapply(x, as_qgis_argument, spec = spec, use_json_input = use_json_input))
+  qgis_dict_input(!!!lapply(x, as_qgis_argument, spec = spec, use_json_input = use_json_input))
 }
 
 #' @export

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -98,229 +98,233 @@ assert_qgis <- function(action = abort) {
 #' @rdname qgis_run
 #' @export
 qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
-  tryCatch({
-    qgis_unconfigure()
+  tryCatch(
+    {
+      qgis_unconfigure()
 
-    version <- as.character(utils::packageVersion("qgisprocess"))
+      version <- as.character(utils::packageVersion("qgisprocess"))
 
-    cache_data_file <- file.path(
-      rappdirs::user_cache_dir("R-qgisprocess"),
-      glue("cache-{version}.rds")
-    )
+      cache_data_file <- file.path(
+        rappdirs::user_cache_dir("R-qgisprocess"),
+        glue("cache-{version}.rds")
+      )
 
-    # Practically all code of this function now consists of handling
-    # use_cached_data = TRUE. This includes cases where qgis_reconfigure() must
-    # be called, when a condition about the cache is not met. Note that
-    # qgis_configure() by default (use_cached_data = FALSE) calls
-    # qgis_reconfigure() straight away.
+      # Practically all code of this function now consists of handling
+      # use_cached_data = TRUE. This includes cases where qgis_reconfigure() must
+      # be called, when a condition about the cache is not met. Note that
+      # qgis_configure() by default (use_cached_data = FALSE) calls
+      # qgis_reconfigure() straight away.
 
 
-    # below message is usually relevant when loading the package, and serves to
-    # announce some waiting time (checking and reading the cache) in case this
-    # process will happen silently (as is the case when loading the pkg). Put
-    # here, since packagestartupmessages in .onLoad are not good practice and
-    # trigger a note during R CMD check. Same applies to the Success! message
-    # further down.
-    if (use_cached_data && quiet) {
-      packageStartupMessage(
-        "Attempting to load the cache ... ",
-        appendLF = FALSE
+      # below message is usually relevant when loading the package, and serves to
+      # announce some waiting time (checking and reading the cache) in case this
+      # process will happen silently (as is the case when loading the pkg). Put
+      # here, since packagestartupmessages in .onLoad are not good practice and
+      # trigger a note during R CMD check. Same applies to the Success! message
+      # further down.
+      if (use_cached_data && quiet) {
+        packageStartupMessage(
+          "Attempting to load the cache ... ",
+          appendLF = FALSE
         )
-    }
+      }
 
-    if (use_cached_data && file.exists(cache_data_file)) {
-      try({
-        cached_data <- readRDS(cache_data_file)
+      if (use_cached_data && file.exists(cache_data_file)) {
+        try({
+          cached_data <- readRDS(cache_data_file)
 
-        if (!quiet) message(glue("Checking configuration in cache file ({cache_data_file})"))
+          if (!quiet) message(glue("Checking configuration in cache file ({cache_data_file})"))
 
-        # CACHE CONDITION: contains minimum required elements (i.e. objects; the
-        # cache is an environment)
-        if (
-          !all(
-            c("path", "version", "algorithms", "plugins", "use_json_output")
-            %in% names(cached_data)
-          )
-        ) {
-          if (quiet) message()
-          message(
-            "The cache does not contain all required elements.\n",
-            "Will try to reconfigure qgisprocess and build new cache ..."
-          )
-          qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
-          return(invisible(has_qgis()))
-        }
-
-        # CACHE CONDITION: the path element does not contradict the environment
-        # variable/option for the qgis_process path
-        option_path <- getOption(
-          "qgisprocess.path",
-          Sys.getenv("R_QGISPROCESS_PATH")
-        )
-
-        if (!identical(option_path, "") && !identical(option_path, cached_data$path)) {
-          if (quiet) message()
-          message(glue(
-            "The user's qgisprocess.path option or the R_QGISPROCESS_PATH environment ",
-            "variable specify a different qgis_process path ({option_path}) ",
-            "than the cache did ({cached_data$path}).\n",
-            "Hence rebuilding cache to reflect this change ..."
-          ))
-          qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
-          return(invisible(has_qgis()))
-        }
-
-        # CACHE CONDITION: the elements checked by has_qgis() look OK
-
-        condition <-
-          is.string(cached_data$version) && nchar(cached_data$version) > 0L &&
-          is.string(cached_data$path) && nchar(cached_data$path) > 0L &&
-          inherits(cached_data$algorithms, "data.frame") &&
-          inherits(cached_data$plugins, "data.frame")
-
-        if (!condition) {
-          if (quiet) message()
-          message(
-            "The cache does not contain all required data.\n",
-            "Will try to reconfigure qgisprocess and build new cache ..."
-          )
-          qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
-          return(invisible(has_qgis()))
-        }
-
-        # CACHE CONDITION: qgis_process is indeed available in the cached path
-
-        tryCatch({
-          qgis_run(path = cached_data$path)
-        }, error = function(e) {
-          if (quiet) message()
-          abort(
-            glue(
-              "'{cached_data$path}' (cached path) is not available anymore.\n",
+          # CACHE CONDITION: contains minimum required elements (i.e. objects; the
+          # cache is an environment)
+          if (
+            !all(
+              c("path", "version", "algorithms", "plugins", "use_json_output")
+              %in% names(cached_data)
+            )
+          ) {
+            if (quiet) message()
+            message(
+              "The cache does not contain all required elements.\n",
               "Will try to reconfigure qgisprocess and build new cache ..."
             )
+            qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
+            return(invisible(has_qgis()))
+          }
+
+          # CACHE CONDITION: the path element does not contradict the environment
+          # variable/option for the qgis_process path
+          option_path <- getOption(
+            "qgisprocess.path",
+            Sys.getenv("R_QGISPROCESS_PATH")
           )
-          qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
+
+          if (!identical(option_path, "") && !identical(option_path, cached_data$path)) {
+            if (quiet) message()
+            message(glue(
+              "The user's qgisprocess.path option or the R_QGISPROCESS_PATH environment ",
+              "variable specify a different qgis_process path ({option_path}) ",
+              "than the cache did ({cached_data$path}).\n",
+              "Hence rebuilding cache to reflect this change ..."
+            ))
+            qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
+            return(invisible(has_qgis()))
+          }
+
+          # CACHE CONDITION: the elements checked by has_qgis() look OK
+
+          condition <-
+            is.string(cached_data$version) && nchar(cached_data$version) > 0L &&
+              is.string(cached_data$path) && nchar(cached_data$path) > 0L &&
+              inherits(cached_data$algorithms, "data.frame") &&
+              inherits(cached_data$plugins, "data.frame")
+
+          if (!condition) {
+            if (quiet) message()
+            message(
+              "The cache does not contain all required data.\n",
+              "Will try to reconfigure qgisprocess and build new cache ..."
+            )
+            qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
+            return(invisible(has_qgis()))
+          }
+
+          # CACHE CONDITION: qgis_process is indeed available in the cached path
+
+          tryCatch(
+            {
+              qgis_run(path = cached_data$path)
+            },
+            error = function(e) {
+              if (quiet) message()
+              abort(
+                glue(
+                  "'{cached_data$path}' (cached path) is not available anymore.\n",
+                  "Will try to reconfigure qgisprocess and build new cache ..."
+                )
+              )
+              qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
+              return(invisible(has_qgis()))
+            })
+
+          # CACHE CONDITION: the cached QGIS version equals the one reported by
+          # qgis_process
+
+          if (!quiet) message(glue(
+            "Checking cached QGIS version with version reported by '{cached_data$path}' ..."
+          ))
+
+          qgisprocess_cache$path <- cached_data$path
+          qversion <- qgis_query_version(quiet = quiet)
+          qgisprocess_cache$path <- NULL
+
+          if (!identical(qversion, cached_data$version)) {
+            if (quiet) message()
+            message(glue(
+              "QGIS version change detected:\n",
+              "- in the qgisprocess cache it was: {cached_data$version}\n",
+              "- while '{cached_data$path}' is at {qversion}\n",
+              "Hence rebuilding cache to reflect this change ..."
+            ))
+            qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
+            return(invisible(has_qgis()))
+          }
+
+          if (!quiet) message(glue("QGIS versions match! ({qversion})"))
+
+          # CACHE CONDITION: the cached QGIS plugins equal the ones reported by
+          # qgis_process, including their state
+
+          if (!quiet) message(glue(
+            "Checking cached QGIS plugins (and state) with those reported by '{cached_data$path}' ..."
+          ))
+
+          qgisprocess_cache$path <- cached_data$path
+          qgisprocess_cache$use_json_output <- cached_data$use_json_output
+          qplugins <- qgis_query_plugins(quiet = quiet)
+          qgisprocess_cache$path <- NULL
+          qgisprocess_cache$use_json_output <- NULL
+
+          if (!identical(qplugins, cached_data$plugins)) {
+            if (quiet) message()
+            message(
+              "Change detected in (enabled) QGIS processing provider plugins!\n",
+              "- in the qgisprocess cache it was:"
+            )
+            print(cached_data$plugins)
+            message(glue(
+              "- while '{cached_data$path}' currently returns:"
+            ))
+            print(qplugins)
+            message(
+              "Hence rebuilding cache to reflect this change ..."
+            )
+            qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
+            return(invisible(has_qgis()))
+          }
+
+          if (!quiet) {
+            message(glue(
+              "QGIS plugins match! ({ sum(qplugins$enabled) } ",
+              "processing provider plugin(s) enabled)"
+            ))
+            message_disabled_plugins(qplugins, prepend_newline = TRUE)
+          }
+
+          # ASSIGNING CACHE OBJECTS
+
+          if (!quiet) message(glue(
+            "\n\nRestoring configuration from '{cache_data_file}'"
+          ))
+
+          qgisprocess_cache$path <- cached_data$path
+          qgisprocess_cache$version <- cached_data$version
+          qgisprocess_cache$use_json_output <- cached_data$use_json_output
+          qgisprocess_cache$algorithms <- cached_data$algorithms
+          qgisprocess_cache$plugins <- cached_data$plugins
+          qgisprocess_cache$loaded_from <- cache_data_file
+
+          # FINAL HANDLING OF SUCCESSFUL use_cached_data = TRUE
+
+          if (!quiet) {       # triggers messages
+            invisible(qgis_version(query = FALSE, quiet = FALSE))
+            invisible(qgis_path(query = FALSE, quiet = FALSE))
+            invisible(qgis_use_json_output(query = FALSE, quiet = FALSE))
+            message(
+              ifelse(qgis_use_json_input(), "Using ", "Not using "),
+              "JSON for input serialization."
+            )
+            invisible(qgis_plugins(query = FALSE, quiet = FALSE, msg = FALSE))
+            invisible(qgis_algorithms(query = FALSE, quiet = FALSE))
+            message_inspect_cache()
+          }
+
+          # usually applicable only on loading the package:
+          if (quiet && !is.null(qgisprocess_cache$loaded_from)) {
+            (packageStartupMessage("Success!"))
+          }
+
           return(invisible(has_qgis()))
+
         })
+      }
 
-        # CACHE CONDITION: the cached QGIS version equals the one reported by
-        # qgis_process
+      if (use_cached_data && !file.exists(cache_data_file)) {
+        message(
+          "No cache found.\n",
+          "Will try to reconfigure qgisprocess and build new cache ..."
+        )
+      }
 
-        if (!quiet) message(glue(
-          "Checking cached QGIS version with version reported by '{cached_data$path}' ..."
-        ))
+      # use_cached_data = FALSE or cache is missing:
 
-        qgisprocess_cache$path <- cached_data$path
-        qversion <- qgis_query_version(quiet = quiet)
-        qgisprocess_cache$path <- NULL
+      qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
 
-        if (!identical(qversion, cached_data$version)) {
-          if (quiet) message()
-          message(glue(
-            "QGIS version change detected:\n",
-            "- in the qgisprocess cache it was: {cached_data$version}\n",
-            "- while '{cached_data$path}' is at {qversion}\n",
-            "Hence rebuilding cache to reflect this change ..."
-          ))
-          qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
-          return(invisible(has_qgis()))
-        }
-
-        if (!quiet) message(glue("QGIS versions match! ({qversion})"))
-
-        # CACHE CONDITION: the cached QGIS plugins equal the ones reported by
-        # qgis_process, including their state
-
-        if (!quiet) message(glue(
-          "Checking cached QGIS plugins (and state) with those reported by '{cached_data$path}' ..."
-        ))
-
-        qgisprocess_cache$path <- cached_data$path
-        qgisprocess_cache$use_json_output <- cached_data$use_json_output
-        qplugins <- qgis_query_plugins(quiet = quiet)
-        qgisprocess_cache$path <- NULL
-        qgisprocess_cache$use_json_output <- NULL
-
-        if (!identical(qplugins, cached_data$plugins)) {
-          if (quiet) message()
-          message(
-            "Change detected in (enabled) QGIS processing provider plugins!\n",
-            "- in the qgisprocess cache it was:"
-          )
-          print(cached_data$plugins)
-          message(glue(
-            "- while '{cached_data$path}' currently returns:"
-          ))
-          print(qplugins)
-          message(
-            "Hence rebuilding cache to reflect this change ..."
-          )
-          qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
-          return(invisible(has_qgis()))
-        }
-
-        if (!quiet) {
-          message(glue(
-          "QGIS plugins match! ({ sum(qplugins$enabled) } ",
-          "processing provider plugin(s) enabled)"
-          ))
-          message_disabled_plugins(qplugins, prepend_newline = TRUE)
-        }
-
-        # ASSIGNING CACHE OBJECTS
-
-        if (!quiet) message(glue(
-          "\n\nRestoring configuration from '{cache_data_file}'"
-        ))
-
-        qgisprocess_cache$path <- cached_data$path
-        qgisprocess_cache$version <- cached_data$version
-        qgisprocess_cache$use_json_output <- cached_data$use_json_output
-        qgisprocess_cache$algorithms <- cached_data$algorithms
-        qgisprocess_cache$plugins <- cached_data$plugins
-        qgisprocess_cache$loaded_from <- cache_data_file
-
-        # FINAL HANDLING OF SUCCESSFUL use_cached_data = TRUE
-
-        if (!quiet) {       # triggers messages
-          invisible(qgis_version(query = FALSE, quiet = FALSE))
-          invisible(qgis_path(query = FALSE, quiet = FALSE))
-          invisible(qgis_use_json_output(query = FALSE, quiet = FALSE))
-          message(
-            ifelse(qgis_use_json_input(), "Using ", "Not using "),
-            "JSON for input serialization."
-          )
-          invisible(qgis_plugins(query = FALSE, quiet = FALSE, msg = FALSE))
-          invisible(qgis_algorithms(query = FALSE, quiet = FALSE))
-          message_inspect_cache()
-        }
-
-        # usually applicable only on loading the package:
-        if (quiet && !is.null(qgisprocess_cache$loaded_from)) {
-          (packageStartupMessage("Success!"))
-        }
-
-        return(invisible(has_qgis()))
-
-      })
-    }
-
-    if (use_cached_data && !file.exists(cache_data_file)) {
-      message(
-        "No cache found.\n",
-        "Will try to reconfigure qgisprocess and build new cache ..."
-      )
-    }
-
-    # use_cached_data = FALSE or cache is missing:
-
-    qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
-
-  }, error = function(e) {
-    qgis_unconfigure()
-    if (!quiet) message(e)
-  })
+    },
+    error = function(e) {
+      qgis_unconfigure()
+      if (!quiet) message(e)
+    })
 
   invisible(has_qgis())
 }
@@ -404,8 +408,8 @@ qgis_version <- function(query = FALSE, quiet = TRUE) {
 
   if (!quiet) {
     message("QGIS version",
-            ifelse(query, " is now set to: ", ": "),
-            qgisprocess_cache$version)
+      ifelse(query, " is now set to: ", ": "),
+      qgisprocess_cache$version)
   }
 
   qgisprocess_cache$version
@@ -444,13 +448,15 @@ qgis_query_path <- function(quiet = FALSE) {
   if (!is.null(getOption("qgisprocess.path"))) {
     path <- getOption("qgisprocess.path", "qgis_process")
     if (!quiet) message(glue("Trying getOption('qgisprocess.path'): '{ path }'"))
-    tryCatch({
-      qgis_run(path = path)
-      if (!quiet) message("Success!")
-      return(path)
-    }, error = function(e) {
-      if (!quiet) message(as.character(e))
-    })
+    tryCatch(
+      {
+        qgis_run(path = path)
+        if (!quiet) message("Success!")
+        return(path)
+      },
+      error = function(e) {
+        if (!quiet) message(as.character(e))
+      })
   } else {
     if (!quiet) message("getOption('qgisprocess.path') was not found.")
   }
@@ -458,25 +464,29 @@ qgis_query_path <- function(quiet = FALSE) {
   if (Sys.getenv("R_QGISPROCESS_PATH", "") != "") {
     path <- Sys.getenv("R_QGISPROCESS_PATH")
     if (!quiet) message(glue("Trying Sys.getenv('R_QGISPROCESS_PATH'): '{ path }'"))
-    tryCatch({
-      qgis_run(path = path)
-      if (!quiet) message("Success!")
-      return(path)
-    }, error = function(e) {
-      if (!quiet) message(as.character(e))
-    })
+    tryCatch(
+      {
+        qgis_run(path = path)
+        if (!quiet) message("Success!")
+        return(path)
+      },
+      error = function(e) {
+        if (!quiet) message(as.character(e))
+      })
   } else {
     if (!quiet) message("Sys.getenv('R_QGISPROCESS_PATH') was not found.")
   }
 
   if (!quiet) message(glue("Trying 'qgis_process' on PATH..."))
-  tryCatch({
-    qgis_run(path = "qgis_process")
-    if (!quiet) message("Success!")
-    return("qgis_process")
-  }, error = function(e) {
-    if (!quiet) message("'qgis_process' is not available on PATH.")
-  })
+  tryCatch(
+    {
+      qgis_run(path = "qgis_process")
+      if (!quiet) message("Success!")
+      return("qgis_process")
+    },
+    error = function(e) {
+      if (!quiet) message("'qgis_process' is not available on PATH.")
+    })
 
   possible_locs <- if (is_macos()) {
     qgis_detect_macos()
@@ -501,11 +511,13 @@ qgis_query_path <- function(quiet = FALSE) {
 
   for (path in possible_locs) {
     if (!quiet) message(glue("Trying command '{ path }'"))
-    tryCatch({
-      qgis_run(path = path)
-      if (!quiet) message("Success!")
-      return(path)
-    }, error = function(e) {})
+    tryCatch(
+      {
+        qgis_run(path = path)
+        if (!quiet) message("Success!")
+        return(path)
+      },
+      error = function(e) {})
   }
 
   abort("QGIS installation found, but all candidate paths failed to execute.")
@@ -538,7 +550,7 @@ qgis_use_json_output <- function(query = FALSE, quiet = TRUE) {
   if (!quiet) message(
     ifelse(qgisprocess_cache$use_json_output, "Using ", "Not using "),
     "JSON for output serialization."
-    )
+  )
 
   qgisprocess_cache$use_json_output
 }
@@ -583,20 +595,20 @@ qgis_query_version <- function(quiet = FALSE) {
   if (length(match) == 0L) abort_query_version(lines = lines)
   if (
     !stringr::str_detect(match[1], "-[Mm]a(ster|in)$") &&
-    !stringr::str_detect(match[1], "^\\d{1,2}\\.\\d*[13579][\\.-]")
+      !stringr::str_detect(match[1], "^\\d{1,2}\\.\\d*[13579][\\.-]")
   ) {
     return(match[1])
   } else {
     if (length(match) < 2L) abort_query_version(lines = lines)
     if (!stringr::str_detect(match[2], "^[0-9a-f]{7,}$")) {
       warning("Please consider building the QGIS development version from ",
-              "within the QGIS git repository, in order to have a unique ",
-              "version identifier of QGIS, or propose the people making the ",
-              "QGIS build to do so. ",
-              "Currently the specific version identifier is '",
-              match[2],
-              "'.",
-              call. = TRUE)
+        "within the QGIS git repository, in order to have a unique ",
+        "version identifier of QGIS, or propose the people making the ",
+        "QGIS build to do so. ",
+        "Currently the specific version identifier is '",
+        match[2],
+        "'.",
+        call. = TRUE)
       match[2] <- paste("unclear:", match[2])
     }
     return(paste0(match[1], ", development state ", match[2]))

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -205,7 +205,8 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
               )
               qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
               return(invisible(has_qgis()))
-            })
+            }
+          )
 
           # CACHE CONDITION: the cached QGIS version equals the one reported by
           # qgis_process
@@ -286,7 +287,7 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
 
           # FINAL HANDLING OF SUCCESSFUL use_cached_data = TRUE
 
-          if (!quiet) {       # triggers messages
+          if (!quiet) { # triggers messages
             invisible(qgis_version(query = FALSE, quiet = FALSE))
             invisible(qgis_path(query = FALSE, quiet = FALSE))
             invisible(qgis_use_json_output(query = FALSE, quiet = FALSE))
@@ -305,7 +306,6 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
           }
 
           return(invisible(has_qgis()))
-
         })
       }
 
@@ -319,12 +319,12 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
       # use_cached_data = FALSE or cache is missing:
 
       qgis_reconfigure(cache_data_file = cache_data_file, quiet = quiet)
-
     },
     error = function(e) {
       qgis_unconfigure()
       if (!quiet) message(e)
-    })
+    }
+  )
 
   invisible(has_qgis())
 }
@@ -334,7 +334,6 @@ qgis_configure <- function(quiet = FALSE, use_cached_data = FALSE) {
 
 #' @keywords internal
 qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
-
   path <- qgis_path(query = TRUE, quiet = quiet)
   if (!quiet) message()
 
@@ -373,7 +372,6 @@ qgis_reconfigure <- function(cache_data_file, quiet = FALSE) {
   })
 
   if (!quiet) message_inspect_cache()
-
 }
 
 
@@ -407,9 +405,11 @@ qgis_version <- function(query = FALSE, quiet = TRUE) {
   if (query) qgisprocess_cache$version <- qgis_query_version(quiet = quiet)
 
   if (!quiet) {
-    message("QGIS version",
+    message(
+      "QGIS version",
       ifelse(query, " is now set to: ", ": "),
-      qgisprocess_cache$version)
+      qgisprocess_cache$version
+    )
   }
 
   qgisprocess_cache$version
@@ -456,7 +456,8 @@ qgis_query_path <- function(quiet = FALSE) {
       },
       error = function(e) {
         if (!quiet) message(as.character(e))
-      })
+      }
+    )
   } else {
     if (!quiet) message("getOption('qgisprocess.path') was not found.")
   }
@@ -472,7 +473,8 @@ qgis_query_path <- function(quiet = FALSE) {
       },
       error = function(e) {
         if (!quiet) message(as.character(e))
-      })
+      }
+    )
   } else {
     if (!quiet) message("Sys.getenv('R_QGISPROCESS_PATH') was not found.")
   }
@@ -486,7 +488,8 @@ qgis_query_path <- function(quiet = FALSE) {
     },
     error = function(e) {
       if (!quiet) message("'qgis_process' is not available on PATH.")
-    })
+    }
+  )
 
   possible_locs <- if (is_macos()) {
     qgis_detect_macos()
@@ -517,7 +520,8 @@ qgis_query_path <- function(quiet = FALSE) {
         if (!quiet) message("Success!")
         return(path)
       },
-      error = function(e) {})
+      error = function(e) {}
+    )
   }
 
   abort("QGIS installation found, but all candidate paths failed to execute.")
@@ -608,7 +612,8 @@ qgis_query_version <- function(quiet = FALSE) {
         "Currently the specific version identifier is '",
         match[2],
         "'.",
-        call. = TRUE)
+        call. = TRUE
+      )
       match[2] <- paste("unclear:", match[2])
     }
     return(paste0(match[1], ", development state ", match[2]))

--- a/R/qgis-detect.R
+++ b/R/qgis-detect.R
@@ -1,4 +1,3 @@
-
 #' Detect QGIS installations with 'qgis_process'
 #'
 #' @param drive_letter The drive letter on which to search. By default,

--- a/R/qgis-function.R
+++ b/R/qgis-function.R
@@ -90,7 +90,7 @@ qgis_function <- function(algorithm, ...) {
   qgis_algorithm_call <- rlang::call2(
     "qgis_run_algorithm",
     algorithm,
-    !!! qgis_algorithm_args,
+    !!!qgis_algorithm_args,
     .ns = "qgisprocess"
   )
 

--- a/R/qgis-function.R
+++ b/R/qgis-function.R
@@ -1,4 +1,3 @@
-
 #' Create functions from QGIS algorithms
 #'
 #' As opposed to [qgis_run_algorithm()], [qgis_function()] creates a callable

--- a/R/qgis-help.R
+++ b/R/qgis-help.R
@@ -237,4 +237,3 @@ help_cache_file <- function(algorithm, json) {
     glue("help-{ alg }-{ hash }.rds")
   )
 }
-

--- a/R/qgis-help.R
+++ b/R/qgis-help.R
@@ -1,4 +1,3 @@
-
 #' Show algorithm help
 #'
 #' @inheritParams qgis_run_algorithm
@@ -186,7 +185,8 @@ qgis_parsed_help <- function(algorithm) {
     sec_outputs,
     stringr::regex(
       paste0(
-        "^([A-Za-z0-9_]+):\\s+<([A-Za-z0-9_ .-]+)>\n\\s([A-Za-z0-9_ .]+)\\s*"),
+        "^([A-Za-z0-9_]+):\\s+<([A-Za-z0-9_ .-]+)>\n\\s([A-Za-z0-9_ .]+)\\s*"
+      ),
       dotall = TRUE, multiline = TRUE
     )
   )[[1]]
@@ -198,7 +198,7 @@ qgis_parsed_help <- function(algorithm) {
     description = sec_description,
     arguments = tibble::tibble(
       name = vapply(arg_info, "[[", 1, FUN.VALUE = character(1)),
-      description =  vapply(arg_info, "[[", 2, FUN.VALUE = character(1)),
+      description = vapply(arg_info, "[[", 2, FUN.VALUE = character(1)),
       qgis_type = arg_type,
       available_values = arg_available,
       acceptable_values = arg_acceptable

--- a/R/qgis-output.R
+++ b/R/qgis-output.R
@@ -1,4 +1,3 @@
-
 qgis_parse_results <- function(algorithm, output) {
   if (stringr::str_detect(output, "^\\s*\\{")) {
     output_parsed <- jsonlite::fromJSON(output)
@@ -45,8 +44,7 @@ qgis_parse_results <- function(algorithm, output) {
 #   "outputLayer"
 # )
 qgis_parse_result_output <- function(value, qgis_output_type) {
-  switch(
-    qgis_output_type,
+  switch(qgis_output_type,
 
     # numbers and strings have clear mappings to R types
     outputNumber = as.numeric(value),
@@ -67,13 +65,11 @@ qgis_parse_result_output <- function(value, qgis_output_type) {
 }
 
 qgis_result_output <- function(value, qgis_output_type) {
-  switch(
-    qgis_output_type,
+  switch(qgis_output_type,
 
     # numbers and strings have clear mappings to R types
     outputNumber = as.numeric(value %||% NA_character_),
     outputString = as.character(value %||% NA_character_),
-
     outputMultilayer = structure(as.character(value), class = paste0("qgis_", qgis_output_type)),
 
     # by default, a classed string that can be reinterpreted

--- a/R/qgis-plugins.R
+++ b/R/qgis-plugins.R
@@ -34,9 +34,7 @@ qgis_plugins <- function(
     which = "all",
     query = FALSE,
     quiet = TRUE,
-    ...
-    ) {
-
+    ...) {
   assert_that(which %in% c("all", "enabled", "disabled"))
   assert_that(is.flag(query), !is.na(query))
   assert_that(is.flag(quiet), !is.na(quiet))
@@ -63,8 +61,7 @@ qgis_plugins <- function(
     "available processing provider plugins are enabled."
   ))
 
-  switch(
-    which,
+  switch(which,
     "all" = plugins,
     "enabled" = plugins[plugins$enabled, ],
     "disabled" = plugins[!plugins$enabled, ]
@@ -75,17 +72,13 @@ qgis_plugins <- function(
 
 #' @keywords internal
 qgis_query_plugins <- function(quiet = FALSE) {
-
   if (qgis_use_json_output()) {
-
     out <- qgis_run(args = c("plugins", "--json"))$stdout
     pluginlist <- jsonlite::fromJSON(out)$plugins
     plugins <- tibble::enframe(pluginlist)
     plugins$value <- unlist(plugins$value, use.names = FALSE)
     colnames(plugins) <- c("name", "enabled")
-
   } else {
-
     lines <- readLines(textConnection(qgis_run("plugins")$stdout))
     pluginvec <- stringr::str_extract(lines, "^\\*?\\s+\\w+")
     pluginvec <- pluginvec[!is.na(pluginvec)]
@@ -93,7 +86,6 @@ qgis_query_plugins <- function(quiet = FALSE) {
       name = stringr::str_match(pluginvec, "^\\*?\\s+(\\w+)")[, 2],
       enabled = stringr::str_detect(pluginvec, "^\\*")
     )
-
   }
 
   plugins
@@ -107,8 +99,7 @@ qgis_query_plugins <- function(quiet = FALSE) {
 message_disabled_plugins <- function(
     plugins,
     prepend_newline = FALSE,
-    startup = FALSE
-    ) {
+    startup = FALSE) {
   if (!identical(sum(plugins$enabled), nrow(plugins))) {
     if (prepend_newline && !startup) message()
     msg <- glue(
@@ -148,7 +139,6 @@ qgis_disable_plugins <- function(names = NULL, quiet = FALSE) {
 
 #' @keywords internal
 handle_plugins <- function(names = NULL, quiet = FALSE, mode) {
-
   assert_that(is.flag(quiet), !is.na(quiet))
   assert_that(mode %in% c("enable", "disable"))
 
@@ -212,7 +202,8 @@ enable_plugin <- function(name, quiet = FALSE) {
         "'{name}' was not successfully enabled. Error message was: ",
         e$stderr
       ))
-    })
+    }
+  )
 }
 
 
@@ -229,5 +220,6 @@ disable_plugin <- function(name, quiet = FALSE) {
         "'{name}' was not successfully disabled. Error message was: ",
         e$stderr
       ))
-    })
+    }
+  )
 }

--- a/R/qgis-plugins.R
+++ b/R/qgis-plugins.R
@@ -35,7 +35,7 @@ qgis_plugins <- function(
     query = FALSE,
     quiet = TRUE,
     ...
-) {
+    ) {
 
   assert_that(which %in% c("all", "enabled", "disabled"))
   assert_that(is.flag(query), !is.na(query))
@@ -108,9 +108,9 @@ message_disabled_plugins <- function(
     plugins,
     prepend_newline = FALSE,
     startup = FALSE
-) {
+    ) {
   if (!identical(sum(plugins$enabled), nrow(plugins))) {
-    if(prepend_newline && !startup) message()
+    if (prepend_newline && !startup) message()
     msg <- glue(
       'Run `qgis_enable_plugins()` to enable ',
       '{ sum(!plugins$enabled) } disabled ',
@@ -164,12 +164,12 @@ handle_plugins <- function(names = NULL, quiet = FALSE, mode) {
     names_unavailable <- names_old[!names_old %in% qgis_plugins(which = "all")$name]
     names_skip <- names_old[names_old %in% qgis_plugins(which = moded)$name]
     if (!quiet && length(names_unavailable) > 0L) message(
-        "Ignoring unknown plugins: ",
-        paste(names_unavailable, collapse = ", ")
+      "Ignoring unknown plugins: ",
+      paste(names_unavailable, collapse = ", ")
     )
     if (!quiet && length(names_skip) > 0L) message(glue(
-        "Ignoring plugins that are {moded} already: ",
-        "{paste(names_skip, collapse = ', ')}"
+      "Ignoring plugins that are {moded} already: ",
+      "{paste(names_skip, collapse = ', ')}"
     ))
     names <- names_old[names_old %in% qgis_plugins(which = moded_rev)$name]
     if (!quiet && "processing" %in% names) message(
@@ -202,31 +202,32 @@ handle_plugins <- function(names = NULL, quiet = FALSE, mode) {
 
 #' @keywords internal
 enable_plugin <- function(name, quiet = FALSE) {
-  tryCatch({
-    qgis_run(args = c("plugins", "enable", name))
-    if (!quiet) message(name, " successfully enabled!")
-  }, error = function(e) {
-    message(glue(
-      "'{name}' was not successfully enabled. Error message was: ",
-      e$stderr
-    ))
-  })
+  tryCatch(
+    {
+      qgis_run(args = c("plugins", "enable", name))
+      if (!quiet) message(name, " successfully enabled!")
+    },
+    error = function(e) {
+      message(glue(
+        "'{name}' was not successfully enabled. Error message was: ",
+        e$stderr
+      ))
+    })
 }
 
 
 
 #' @keywords internal
 disable_plugin <- function(name, quiet = FALSE) {
-  tryCatch({
-    qgis_run(args = c("plugins", "disable", name))
-    if (!quiet) message(name, " successfully disabled!")
-  }, error = function(e) {
-    message(glue(
-      "'{name}' was not successfully disabled. Error message was: ",
-      e$stderr
-    ))
-  })
+  tryCatch(
+    {
+      qgis_run(args = c("plugins", "disable", name))
+      if (!quiet) message(name, " successfully disabled!")
+    },
+    error = function(e) {
+      message(glue(
+        "'{name}' was not successfully disabled. Error message was: ",
+        e$stderr
+      ))
+    })
 }
-
-
-

--- a/R/qgis-result.R
+++ b/R/qgis-result.R
@@ -1,4 +1,3 @@
-
 #' Access algorithm results
 #'
 #' @param x An object returned by [qgis_run_algorithm()].
@@ -82,7 +81,6 @@ qgis_result_single <- function(x, what) {
   result <- x[grepl("^(output|OUTPUT)$", names(x))][1][[1]]
   if (is.null(result)) result <- x[[1]]
   result
-
 }
 
 

--- a/R/qgis-result.R
+++ b/R/qgis-result.R
@@ -66,7 +66,6 @@ qgis_check_stdout <- function(x) {
 #' @rdname is_qgis_result
 #' @export
 qgis_result_single <- function(x, what) {
-
   # Limit result to elements that match class
   x <- x[vapply(x, inherits, what, FUN.VALUE = logical(1))]
   if (length(x) == 0L) {

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -44,7 +44,7 @@ qgis_run_algorithm <- function(algorithm, ..., PROJECT_PATH = NULL, ELLIPSOID = 
     # sanitize arguments and make sure they are cleaned up on exit
     args <- qgis_sanitize_arguments(
       algorithm,
-      !!! dots,
+      !!!dots,
       PROJECT_PATH = PROJECT_PATH,
       ELLIPSOID = ELLIPSOID,
       .use_json_input = use_json_input
@@ -93,7 +93,7 @@ qgis_run_algorithm <- function(algorithm, ..., PROJECT_PATH = NULL, ELLIPSOID = 
   # about the output
   result <- structure(
     rlang::list2(
-      !!! qgis_parse_results(algorithm, result$stdout),
+      !!!qgis_parse_results(algorithm, result$stdout),
       .algorithm = algorithm,
       .args = args,
       .raw_json_input = if (use_json_input) args_str,

--- a/R/qgis-run-algorithm.R
+++ b/R/qgis-run-algorithm.R
@@ -1,4 +1,3 @@
-
 #' Run algorithms using 'qgis_process'
 #'
 #' Run QGIS algorithms.

--- a/R/qgis-tmp.R
+++ b/R/qgis-tmp.R
@@ -1,4 +1,3 @@
-
 #' Manage temporary files
 #'
 #' These functions create temporary files that can be used

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,3 @@
-
 # nocov start
 
 .onLoad <- function(...) {

--- a/data-raw/qgis_cached_algorithms.R
+++ b/data-raw/qgis_cached_algorithms.R
@@ -1,4 +1,3 @@
-
 # The algorithm list is always available, but the help text
 # associated with all algorithms can take up to an hour to load
 # because it takes so many calls to qgis_process. This builds

--- a/tests/platform-info.R
+++ b/tests/platform-info.R
@@ -1,4 +1,3 @@
-
 library(qgisprocess)
 
 qgis_configure()

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,9 +1,9 @@
 local_flipped_json_output <- function() {
-    # FLIPPING qgis_use_json_output() STATE
-    withr::local_options(qgisprocess.use_json_output = !qgis_use_json_output())
-    qgis_use_json_output(query = TRUE) # updates cache environment
-    # plan to restore this cache setting before exiting the test:
-    withr::defer_parent(qgis_use_json_output(query = TRUE), priority = "last")
+  # FLIPPING qgis_use_json_output() STATE
+  withr::local_options(qgisprocess.use_json_output = !qgis_use_json_output())
+  qgis_use_json_output(query = TRUE) # updates cache environment
+  # plan to restore this cache setting before exiting the test:
+  withr::defer_parent(qgis_use_json_output(query = TRUE), priority = "last")
 }
 
 expect_correct_plugins_format <- function(plugins) {

--- a/tests/testthat/test-compat-raster.R
+++ b/tests/testthat/test-compat-raster.R
@@ -1,4 +1,3 @@
-
 test_that("raster argument coercers work", {
   skip_if_not_installed("raster")
 

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -117,7 +117,7 @@ test_that("sfc to QGIS point work", {
 test_that("sfc to QGIS point rasises issues", {
   skip_if_not_installed("sf")
 
-  points <- sf::st_sfc(list(sf::st_point(c(1, 2)),sf::st_point(c(1, 2))), crs = sf::st_crs("EPSG:5514"))
+  points <- sf::st_sfc(list(sf::st_point(c(1, 2)), sf::st_point(c(1, 2))), crs = sf::st_crs("EPSG:5514"))
 
   expect_error(
     as_qgis_argument(
@@ -153,7 +153,7 @@ test_that("sf to QGIS point rasises issues", {
     "Can't convert 'sfc' object to QGIS type 'point' as the length is not equal to 1"
   )
 
-  points <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))[1,]
+  points <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))[1, ]
 
   expect_error(
     as_qgis_argument(
@@ -184,7 +184,7 @@ test_that("sf to QGIS point work", {
   data <- sf::st_transform(data, sf::st_crs("EPSG:32019"))
 
   suppressWarnings(
-    points <- sf::st_centroid(data[1,])
+    points <- sf::st_centroid(data[1, ])
   )
 
   point_representation <- expect_match(

--- a/tests/testthat/test-compat-sf.R
+++ b/tests/testthat/test-compat-sf.R
@@ -1,4 +1,3 @@
-
 test_that("sf argument coercers work", {
   skip_if_not_installed("sf")
   sf_obj <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))
@@ -192,7 +191,8 @@ test_that("sf to QGIS point work", {
       points,
       qgis_argument_spec(qgis_type = "point")
     ),
-    "1265036\\.90059[0-9]+,985175\\.481905[0-9]+\\[EPSG:32019\\]")
+    "1265036\\.90059[0-9]+,985175\\.481905[0-9]+\\[EPSG:32019\\]"
+  )
 
   expect_s3_class(point_representation, "character")
 })

--- a/tests/testthat/test-compat-stars.R
+++ b/tests/testthat/test-compat-stars.R
@@ -1,4 +1,3 @@
-
 test_that("stars argument coercers work", {
   skip_if_not_installed("stars")
 

--- a/tests/testthat/test-compat-terra.R
+++ b/tests/testthat/test-compat-terra.R
@@ -1,4 +1,3 @@
-
 test_that("terra argument coercers work", {
   skip_if_not_installed("terra")
 
@@ -63,7 +62,6 @@ test_that("terra result coercers work", {
     ),
     "SpatRaster"
   )
-
 })
 
 test_that("terra argument coercer for extent works", {

--- a/tests/testthat/test-qgis-algorithm.R
+++ b/tests/testthat/test-qgis-algorithm.R
@@ -1,4 +1,3 @@
-
 test_that("qgis_has_algorithm() works", {
   skip_if_not(has_qgis())
   expect_true(qgis_has_algorithm("native:filedownloader"))

--- a/tests/testthat/test-qgis-arguments.R
+++ b/tests/testthat/test-qgis-arguments.R
@@ -102,12 +102,12 @@ test_that("qgis_serialize_arguments() outputs correct JSON strings", {
             name = "name",
             precision = 0L,
             type = 10L
-            )
           )
-        ),
+        )
+      ),
       project_path = "test.qgs"
-      )
     )
+  )
 })
 
 test_that("argument coercers work", {

--- a/tests/testthat/test-qgis-arguments.R
+++ b/tests/testthat/test-qgis-arguments.R
@@ -1,4 +1,3 @@
-
 test_that("qgis_sanitize_arguments() ignores unknown inputs", {
   expect_message(
     expect_identical(

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -1,4 +1,3 @@
-
 test_that("qgis_version() works", {
   skip_if_not(has_qgis())
 

--- a/tests/testthat/test-qgis-detect.R
+++ b/tests/testthat/test-qgis-detect.R
@@ -1,4 +1,3 @@
-
 test_that("qgis_detect_macos() works", {
   if (is_macos()) {
     expect_type(qgis_detect_macos(), "character")

--- a/tests/testthat/test-qgis-function.R
+++ b/tests/testthat/test-qgis-function.R
@@ -54,4 +54,3 @@ test_that("qgis_pipe() works", {
 
   expect_s3_class(result, "qgis_result")
 })
-

--- a/tests/testthat/test-qgis-function.R
+++ b/tests/testthat/test-qgis-function.R
@@ -1,4 +1,3 @@
-
 test_that("qgis_function() works", {
   skip_if_not(has_qgis())
 

--- a/tests/testthat/test-qgis-help.R
+++ b/tests/testthat/test-qgis-help.R
@@ -1,4 +1,3 @@
-
 test_that("qgis_help_text()/show works", {
   skip_if_not(has_qgis())
   expect_match(qgis_help_text("native:filedownloader"), "native:filedownloader")
@@ -48,7 +47,6 @@ test_that("qgis_arguments() and qgis_outputs() work for selected algorithms", {
     expect_false(any(is.na(qgis_outputs(!!algorithm)$name)))
     expect_false(any(is.na(qgis_outputs(!!algorithm)$qgis_output_type)))
   }
-
 })
 
 test_that("qgis_arguments() and qgis_outputs() works for all algorithms", {

--- a/tests/testthat/test-qgis-help.R
+++ b/tests/testthat/test-qgis-help.R
@@ -13,21 +13,21 @@ test_that("qgis_description() works for algorithms", {
   expect_true("SEGMENTS" %in% qgis_arguments("native:buffer")$name)
 
   for (algorithm in head(qgis_algorithms()$algorithm, 3)) {
-    expect_length(qgis_description(!! algorithm), 1)
-    expect_type(qgis_description(!! algorithm), "character")
+    expect_length(qgis_description(!!algorithm), 1)
+    expect_type(qgis_description(!!algorithm), "character")
   }
 
   for (algorithm in head(qgis_algorithms()$algorithm, 3)) {
-    expect_s3_class(qgis_arguments(!! algorithm), "data.frame")
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$name)))
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$qgis_type)))
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$description)))
+    expect_s3_class(qgis_arguments(!!algorithm), "data.frame")
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$name)))
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$qgis_type)))
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$description)))
   }
 
   for (algorithm in head(qgis_algorithms()$algorithm, 3)) {
-    expect_s3_class(qgis_outputs(!! algorithm), "data.frame")
-    expect_false(any(is.na(qgis_outputs(!! algorithm)$name)))
-    expect_false(any(is.na(qgis_outputs(!! algorithm)$qgis_output_type)))
+    expect_s3_class(qgis_outputs(!!algorithm), "data.frame")
+    expect_false(any(is.na(qgis_outputs(!!algorithm)$name)))
+    expect_false(any(is.na(qgis_outputs(!!algorithm)$qgis_output_type)))
   }
 })
 
@@ -37,16 +37,16 @@ test_that("qgis_arguments() and qgis_outputs() work for selected algorithms", {
   selected_algorithms <- c("native:buffer", "qgis:executesql")
 
   for (algorithm in selected_algorithms) {
-    expect_s3_class(qgis_arguments(!! algorithm), "data.frame")
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$name)))
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$qgis_type)))
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$description)))
+    expect_s3_class(qgis_arguments(!!algorithm), "data.frame")
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$name)))
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$qgis_type)))
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$description)))
   }
 
   for (algorithm in selected_algorithms) {
-    expect_s3_class(qgis_outputs(!! algorithm), "data.frame")
-    expect_false(any(is.na(qgis_outputs(!! algorithm)$name)))
-    expect_false(any(is.na(qgis_outputs(!! algorithm)$qgis_output_type)))
+    expect_s3_class(qgis_outputs(!!algorithm), "data.frame")
+    expect_false(any(is.na(qgis_outputs(!!algorithm)$name)))
+    expect_false(any(is.na(qgis_outputs(!!algorithm)$qgis_output_type)))
   }
 
 })
@@ -55,16 +55,16 @@ test_that("qgis_arguments() and qgis_outputs() works for all algorithms", {
   skip("Test takes ~1 hr to run")
   for (algorithm in qgis_algorithms()$algorithm) {
     if (interactive()) message(algorithm)
-    expect_s3_class(qgis_arguments(!! algorithm), "data.frame")
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$name)))
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$qgis_type)))
-    expect_false(any(is.na(qgis_arguments(!! algorithm)$description)))
+    expect_s3_class(qgis_arguments(!!algorithm), "data.frame")
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$name)))
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$qgis_type)))
+    expect_false(any(is.na(qgis_arguments(!!algorithm)$description)))
   }
 
   for (algorithm in qgis_algorithms()$algorithm) {
-    expect_s3_class(qgis_outputs(!! algorithm), "data.frame")
-    expect_false(any(is.na(qgis_outputs(!! algorithm)$name)))
-    expect_false(any(is.na(qgis_outputs(!! algorithm)$qgis_output_type)))
+    expect_s3_class(qgis_outputs(!!algorithm), "data.frame")
+    expect_false(any(is.na(qgis_outputs(!!algorithm)$name)))
+    expect_false(any(is.na(qgis_outputs(!!algorithm)$qgis_output_type)))
   }
 })
 

--- a/tests/testthat/test-qgis-output.R
+++ b/tests/testthat/test-qgis-output.R
@@ -1,4 +1,3 @@
-
 test_that("characters are not incorrectly re-encoded from output", {
   skip_if_not(has_qgis())
 

--- a/tests/testthat/test-qgis-plugins.R
+++ b/tests/testthat/test-qgis-plugins.R
@@ -91,11 +91,3 @@ test_that("message_disabled_plugins() works", {
     "Run `qgis_enable_plugins\\(\\)`.+access"
   )
 })
-
-
-
-
-
-
-
-

--- a/tests/testthat/test-qgis-plugins.R
+++ b/tests/testthat/test-qgis-plugins.R
@@ -146,7 +146,7 @@ test_that("qgis_*able_plugins() works for a disabled grassprovider plugin", {
   skip_if_not(
     qgis_has_plugin("grassprovider"),
     "The 'grassprovider' plugin is missing."
-    )
+  )
   skip_if(
     subset(qgis_plugins(), name == "grassprovider")$enabled,
     "The 'grassprovider' plugin is enabled."
@@ -186,6 +186,3 @@ test_that("qgis_*able_plugins() works for an enabled grassprovider plugin", {
   )
   expect_true(subset(qgis_plugins(), name == "grassprovider")$enabled)
 })
-
-
-

--- a/tests/testthat/test-qgis-result.R
+++ b/tests/testthat/test-qgis-result.R
@@ -31,8 +31,8 @@ test_that("qgis_result_*() functions work", {
   expect_output(print(result), "^<Result")
   expect_true(
     all(c("INPUT", "FIELD", "OPERATOR", "VALUE", "OUTPUT", "FAIL_OUTPUT") %in%
-          names(qgis_result_args(result)))
-    )
+      names(qgis_result_args(result)))
+  )
   expect_identical(qgis_result_status(result), 0L)
   expect_type(qgis_result_stderr(result), "character")
   expect_type(qgis_result_stdout(result), "character")
@@ -40,7 +40,7 @@ test_that("qgis_result_*() functions work", {
   expect_identical(
     qgis_result_single(result, "qgis_outputVector"),
     result$OUTPUT
-    )
+  )
 
   result$.processx_result$stdout <- ""
   expect_error(qgis_check_stdout(result), "output could not be captured")

--- a/tests/testthat/test-qgis-result.R
+++ b/tests/testthat/test-qgis-result.R
@@ -1,4 +1,3 @@
-
 test_that("qgis_output() works", {
   expect_identical(qgis_output(list(a = 1), "a"), 1)
   expect_identical(qgis_output(list(a = 1), "b", default = 2), 2)

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -57,7 +57,7 @@ test_that(glue("qgis_run_algorithm accepts multiple input arguments{input}"), {
 
   v_1 <- sf::read_sf(system.file("longlake/longlake.gpkg", package = "qgisprocess"))
   v_2 <- v_3 <- v_1
-  v_2$geom = v_2$geom + 1000
+  v_2$geom <- v_2$geom + 1000
   sf::st_crs(v_2) <- sf::st_crs(v_1)
   v_3$geom <- v_3$geom - 1000
   sf::st_crs(v_3) <- sf::st_crs(v_1)

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -79,10 +79,10 @@ test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptab
   capture.output({
     result <- qgis_run_algorithm(
       "qgis:relief",
-      INPUT=system.file("longlake/longlake_depth.tif", package = "qgisprocess"),
-      Z_FACTOR=1,
-      AUTO_COLORS=FALSE,
-      COLORS="-0.5, 0, 170, 0, 0; 0, 0.5, 85, 255, 255; 0.5, 1, 0, 255, 0; 1, 2.5, 85, 85, 255"
+      INPUT = system.file("longlake/longlake_depth.tif", package = "qgisprocess"),
+      Z_FACTOR = 1,
+      AUTO_COLORS = FALSE,
+      COLORS = "-0.5, 0, 170, 0, 0; 0, 0.5, 85, 255, 255; 0.5, 1, 0, 255, 0; 1, 2.5, 85, 85, 255"
     )
   })
 

--- a/tests/testthat/test-qgis-run-algorithm.R
+++ b/tests/testthat/test-qgis-run-algorithm.R
@@ -90,7 +90,6 @@ test_that(glue("qgis_run_algorithm runs with qgis:relief, for which the acceptab
   expect_s3_class(result$FREQUENCY_DISTRIBUTION, "qgis_outputFile")
   expect_true(file.exists(result$OUTPUT))
   expect_true(file.exists(result$FREQUENCY_DISTRIBUTION))
-
 })
 
 

--- a/tests/testthat/test-qgis-run-algorithm2.R
+++ b/tests/testthat/test-qgis-run-algorithm2.R
@@ -2,14 +2,14 @@
 
 if (has_qgis() && package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.23.0") {
 
-withr::local_envvar(c(JSON_INPUT = qgis_use_json_input()))
-withr::local_options(qgisprocess.use_json_input = !qgis_use_json_input())
+  withr::local_envvar(c(JSON_INPUT = qgis_use_json_input()))
+  withr::local_options(qgisprocess.use_json_input = !qgis_use_json_input())
 
   test_that("Flipping JSON input method before re-testing works", {
     expect_identical(
       as.logical(Sys.getenv("JSON_INPUT")),
       !qgis_use_json_input()
-      )
+    )
   })
 
   source("test-qgis-run-algorithm.R", echo = FALSE, local = TRUE)

--- a/tests/testthat/test-qgis-run-algorithm2.R
+++ b/tests/testthat/test-qgis-run-algorithm2.R
@@ -1,7 +1,6 @@
 # Flip qgis_use_json_input() and rerun test-qgis-run-algorithm.R
 
 if (has_qgis() && package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.23.0") {
-
   withr::local_envvar(c(JSON_INPUT = qgis_use_json_input()))
   withr::local_options(qgisprocess.use_json_input = !qgis_use_json_input())
 
@@ -13,5 +12,4 @@ if (has_qgis() && package_version(strsplit(qgis_version(), "-")[[1]][1]) >= "3.2
   })
 
   source("test-qgis-run-algorithm.R", echo = FALSE, local = TRUE)
-
 }

--- a/tests/testthat/test-qgis-tmp.R
+++ b/tests/testthat/test-qgis-tmp.R
@@ -1,4 +1,3 @@
-
 test_that("tempfile generators work", {
   expect_true(dir.exists(qgis_tmp_base()))
   expect_false(is_qgis_tmp_file(qgis_tmp_base()))


### PR DESCRIPTION
See commit messages; incremental steps were taken based on the `scope` and `strict` arguments.

I have had a look at what changed in each step. Most accepted changes were implemented under the `scope = "line_breaks"` choice, one extra has been taken (of two) from `scope = "tokens", strict = FALSE`.

The remainder of the default effect by **styler** (`scope = "tokens", strict = TRUE`) seems rather irrelevant or unwanted (to me); please have a look at https://github.com/paleolimbot/qgisprocess/compare/styler...styler_dump (where those non-incorporated changes can be seen), to verify whether you agree.