### PR TITLE
qgis_version(): add argument 'debug'

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,9 +6,6 @@ on:
       - master
       - main
   pull_request:
-    branches:
-      - master
-      - main
   schedule:
     - cron:  '0 3 * * 4'
 

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -42,6 +42,9 @@
 #' @param use_cached_data Use the cached algorithm list and `path` found when
 #'   configuring qgisprocess during the last session. This saves some time
 #'   loading the package.
+#' @param debug Logical.
+#' If `TRUE`, also output the version of QGIS, the operating system and all
+#' relevant libraries, as reported by the 'qgis_process' command.
 #'
 #' @return The result of [processx::run()].
 #' @export
@@ -399,13 +402,22 @@ qgis_unconfigure <- function() {
 
 #' @rdname qgis_run
 #' @export
-qgis_version <- function(query = FALSE, quiet = TRUE) {
+qgis_version <- function(query = FALSE, quiet = TRUE, debug = FALSE) {
   if (query) qgisprocess_cache$version <- qgis_query_version(quiet = quiet)
 
   if (!quiet) {
     message("QGIS version",
             ifelse(query, " is now set to: ", ": "),
             qgisprocess_cache$version)
+  }
+
+  if (debug) {
+    print(qgisprocess_cache$version)
+    message()
+    message("Versions reported by 'qgis_process':")
+    message("------------------------------------")
+    message(qgis_run(args = "--version")$stdout)
+    return(invisible(qgisprocess_cache$version))
   }
 
   qgisprocess_cache$version

--- a/R/qgis-configure.R
+++ b/R/qgis-configure.R
@@ -34,7 +34,8 @@
 #' @param args Command-line arguments
 #' @param quiet Use `FALSE` to display more information about the command, possibly
 #'   useful for debugging.
-#' @param query Use `TRUE` to refresh the cached value.
+#' @param query Use `TRUE` to replace the cached value by the one reported by
+#' 'qgis_process'.
 #' @param action An action to take if the 'qgis_process' executable could not be
 #'   found.
 #' @param env A [list()] of environment variables. Defaults to [qgis_env()].

--- a/man/qgis_has_algorithm.Rd
+++ b/man/qgis_has_algorithm.Rd
@@ -22,7 +22,8 @@ assert_qgis_algorithm(algorithm)
 \item{algorithm}{A qualified algorithm name (e.g., "native:filedownloader") or
 a path to a QGIS model file.}
 
-\item{query}{Use \code{TRUE} to refresh the cached value.}
+\item{query}{Use \code{TRUE} to replace the cached value by the one reported by
+'qgis_process'.}
 
 \item{quiet}{Use \code{TRUE} to suppress output from processing algorithms.}
 

--- a/man/qgis_plugins.Rd
+++ b/man/qgis_plugins.Rd
@@ -17,7 +17,8 @@ qgis_disable_plugins(names = NULL, quiet = FALSE)
 status in QGIS (enabled or disabled).
 Must be one of: \code{"all"}, \code{"enabled"}, \code{"disabled"}.}
 
-\item{query}{Use \code{TRUE} to refresh the cached value.}
+\item{query}{Use \code{TRUE} to replace the cached value by the one reported by
+'qgis_process'.}
 
 \item{quiet}{Use \code{FALSE} to display more information about the command, possibly
 useful for debugging.}

--- a/man/qgis_run.Rd
+++ b/man/qgis_run.Rd
@@ -23,7 +23,7 @@ qgis_configure(quiet = FALSE, use_cached_data = FALSE)
 
 qgis_unconfigure()
 
-qgis_version(query = FALSE, quiet = TRUE)
+qgis_version(query = FALSE, quiet = TRUE, debug = FALSE)
 
 qgis_path(query = FALSE, quiet = TRUE)
 
@@ -53,6 +53,10 @@ configuring qgisprocess during the last session. This saves some time
 loading the package.}
 
 \item{query}{Use \code{TRUE} to refresh the cached value.}
+
+\item{debug}{Logical.
+If \code{TRUE}, also output the version of QGIS, the operating system and all
+relevant libraries, as reported by the 'qgis_process' command.}
 }
 \value{
 The result of \code{\link[processx:run]{processx::run()}}.

--- a/man/qgis_run.Rd
+++ b/man/qgis_run.Rd
@@ -52,7 +52,8 @@ useful for debugging.}
 configuring qgisprocess during the last session. This saves some time
 loading the package.}
 
-\item{query}{Use \code{TRUE} to refresh the cached value.}
+\item{query}{Use \code{TRUE} to replace the cached value by the one reported by
+'qgis_process'.}
 
 \item{debug}{Logical.
 If \code{TRUE}, also output the version of QGIS, the operating system and all

--- a/tests/platform-info.R
+++ b/tests/platform-info.R
@@ -11,13 +11,13 @@ if (is_windows()) qgis_detect_windows()
 if (has_qgis()) qgis_path()
 if (has_qgis()) qgis_version()
 
+if (has_qgis()) qgis_version(debug = TRUE)
+
 if (has_qgis()) qgis_use_json_output()
 if (has_qgis()) qgis_use_json_input()
 
 if (has_qgis()) cat(qgis_run()$stdout)
 if (has_qgis()) cat(qgis_run()$stderr)
-
-if (has_qgis()) cat(qgis_run(args = "--version")$stdout)
 
 if (has_qgis()) qgis_plugins()
 

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -3,6 +3,11 @@ test_that("qgis_version() works", {
   skip_if_not(has_qgis())
 
   expect_match(qgis_version(), "^\\d{1,2}\\.\\d+.*-.+")
+
+  capture.output({
+    expect_message(qgis_version(debug = TRUE), "PROJ version")
+    expect_message(qgis_version(debug = TRUE), "EPSG ")
+  })
 })
 
 test_that("qgis_query_version() works", {


### PR DESCRIPTION
Argument `debug = TRUE` (default: `FALSE`) triggers `qgis_version()` to report the output of `qgis_process --version` as messages.

This is also implemented in `tests/platform-info.R`.

```r
> qgis_version()
[1] "3.28.3-Firenze"

> qgis_version(query = TRUE)
[1] "3.28.3-Firenze"

> qgis_version(debug = TRUE)
[1] "3.28.3-Firenze"

Versions reported by 'qgis_process':
------------------------------------
QGIS 3.28.3-Firenze 'Firenze' (c12bcb2f76)
QGIS code revision c12bcb2f76
Qt version 5.15.3
Python version 3.10.6
GDAL/OGR version 3.6.2
PROJ version 9.1.1
EPSG Registry database version v10.076 (2022-08-31)
GEOS version 3.11.1-CAPI-1.17.1
SQLite version 3.37.2
OS Linux Mint 21.1

```