### PR TITLE
Some modifications in the result of qgis_algorithms() and qgis_providers()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,8 @@ Imports:
     rlang,
     vctrs,
     jsonlite,
-    rappdirs
+    rappdirs,
+    stats
 URL: https://github.com/paleolimbot/qgisprocess
 BugReports: https://github.com/paleolimbot/qgisprocess/issues
 Suggests: 

--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -48,7 +48,17 @@ qgis_has_provider <- function(provider, query = FALSE, quiet = TRUE) {
 qgis_providers <- function() {
   assert_qgis()
   algs <- qgis_algorithms()
-  algs[!duplicated(algs$provider), c("provider", "provider_title"), drop = FALSE]
+  counted <- stats::aggregate(
+    algs[[1]],
+    by = list(algs$provider, algs$provider_title),
+    FUN = length
+  )
+  tibble::as_tibble(
+    stats::setNames(
+      counted,
+      c("provider", "provider_title", "algorithm_count")
+    )
+  )
 }
 
 #' @rdname qgis_has_algorithm

--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -54,7 +54,7 @@ qgis_providers <- function() {
     FUN = length
   )
   tibble::as_tibble(
-    stats::setNames(
+    rlang::set_names(
       counted,
       c("provider", "provider_title", "algorithm_count")
     )

--- a/R/qgis-algorithms.R
+++ b/R/qgis-algorithms.R
@@ -149,12 +149,16 @@ qgis_query_algorithms <- function(quiet = FALSE) {
 
     # for compatibility with old output
     algs$algorithm_id <- stringr::str_remove(algs$algorithm, "^.*?:")
-    algs$algorithm_title <- algs$name
-    algs$provider_title <- algs$provider_name
-    algs$provider <- algs$provider_id
+    colnames(algs)[colnames(algs) == "name"] <- "algorithm_title"
+    colnames(algs)[colnames(algs) == "provider_name"] <- "provider_title"
+    colnames(algs)[colnames(algs) == "provider_id"] <- "provider"
 
     first_cols <- c("provider", "provider_title", "algorithm", "algorithm_id", "algorithm_title")
-    algs[c(first_cols, setdiff(names(algs), first_cols))]
+    second_cols <- setdiff(
+      names(algs)[grepl("provider", names(algs))],
+      first_cols
+    )
+    algs[c(first_cols, second_cols, setdiff(names(algs), c(first_cols, second_cols)))]
   } else {
     result <- qgis_run(args = "list")
     lines <- trimws(readLines(textConnection(trimws(result$stdout))))

--- a/tests/testthat/test-qgis-algorithms.R
+++ b/tests/testthat/test-qgis-algorithms.R
@@ -1,8 +1,14 @@
 test_that("qgis_algorithms() works", {
   skip_if_not(has_qgis())
-  expect_s3_class(qgis_algorithms(), "data.frame")
-  expect_gt(nrow(qgis_algorithms()), 200)
-  expect_gt(ncol(qgis_algorithms()), 20)
+  algs <- qgis_algorithms()
+  expect_true(tibble::is_tibble(algs))
+  expect_gt(nrow(algs), 200)
+  expect_gt(ncol(algs), 20)
+  old_names <- c(
+    "provider", "provider_title", "algorithm",
+    "algorithm_id", "algorithm_title"
+  )
+  expect_true(all(vapply(algs[old_names], function(x) all(!is.na(x)), logical(1))))
 })
 
 test_that("qgis_has_algorithm() works", {

--- a/tests/testthat/test-qgis-algorithms.R
+++ b/tests/testthat/test-qgis-algorithms.R
@@ -1,3 +1,10 @@
+test_that("qgis_algorithms() works", {
+  skip_if_not(has_qgis())
+  expect_s3_class(qgis_algorithms(), "data.frame")
+  expect_gt(nrow(qgis_algorithms()), 200)
+  expect_gt(ncol(qgis_algorithms()), 20)
+})
+
 test_that("qgis_has_algorithm() works", {
   skip_if_not(has_qgis())
   expect_true(qgis_has_algorithm("native:filedownloader"))
@@ -12,8 +19,10 @@ test_that("qgis_has_provider() works", {
 
 test_that("qgis_providers() works", {
   skip_if_not(has_qgis())
+  expect_s3_class(qgis_providers(), "data.frame")
   expect_true("native" %in% qgis_providers()$provider)
   expect_false("notaprovider" %in% qgis_providers()$provider)
+  expect_identical(ncol(qgis_providers()), 3L)
 })
 
 test_that("assert_qgis_algorithm() works", {

--- a/tests/testthat/test-qgis-algorithms.R
+++ b/tests/testthat/test-qgis-algorithms.R
@@ -29,7 +29,10 @@ test_that("qgis_providers() works", {
   expect_s3_class(qgis_providers(), "data.frame")
   expect_true("native" %in% qgis_providers()$provider)
   expect_false("notaprovider" %in% qgis_providers()$provider)
-  expect_identical(ncol(qgis_providers()), 3L)
+  expect_named(
+    qgis_providers(),
+    c("provider", "provider_title", "algorithm_count")
+  )
 })
 
 test_that("assert_qgis_algorithm() works", {

--- a/tests/testthat/test-qgis-algorithms.R
+++ b/tests/testthat/test-qgis-algorithms.R
@@ -8,6 +8,7 @@ test_that("qgis_algorithms() works", {
     "provider", "provider_title", "algorithm",
     "algorithm_id", "algorithm_title"
   )
+  # check that the 'old_names' columns have complete data (no NAs):
   expect_true(all(vapply(algs[old_names], function(x) all(!is.na(x)), logical(1))))
 })
 

--- a/tests/testthat/test-qgis-configure.R
+++ b/tests/testthat/test-qgis-configure.R
@@ -37,20 +37,6 @@ test_that("qgis_query_version() works for development versions of QGIS", {
   }
 })
 
-test_that("qgis_algorithms() works", {
-  skip_if_not(has_qgis())
-
-  algs <- qgis_algorithms()
-  expect_true(tibble::is_tibble(algs))
-  expect_true(nrow(algs) > 1)
-
-  old_names <- c(
-    "provider", "provider_title", "algorithm",
-    "algorithm_id", "algorithm_title"
-  )
-  expect_true(all(vapply(algs[old_names], function(x) all(!is.na(x)), logical(1))))
-})
-
 test_that("qgis_configure() returns FALSE with no QGIS", {
   skip_if(has_qgis())
   expect_false(


### PR DESCRIPTION
This is purely for cosmetic and informational purposes.

- In the old `qgis_algorithms()` result, there were three duplicated columns (because the function code created them) and some `provider_*` columns were scattered around. This is now solved.
- `qgis_providers()` now also returns the number of algorithms per provider, turning it more into a summary of the package state. Also, sorting is now according to `provider_title` instead of `provider`, resulting in a more convenient grouping.

#### Old behaviour

```r
> dplyr::glimpse(qgis_algorithms())
Rows: 785
Columns: 27
$ provider                           <chr> "3d", "cartographytools", "cartographytools", "cartographytools", "ca…
$ provider_title                     <chr> "QGIS (3D)", "Cartography tools", "Cartography tools", "Cartography t…
$ algorithm                          <chr> "3d:tessellate", "cartographytools:averagelines", "cartographytools:c…
$ algorithm_id                       <chr> "tessellate", "averagelines", "collapsedualcarriageway", "removecross…
$ algorithm_title                    <chr> "Tessellate", "Average linestrings", "Collapse dual carriageways", "R…
$ provider_id                        <chr> "3d", "cartographytools", "cartographytools", "cartographytools", "ca…
$ can_cancel                         <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRU…
$ deprecated                         <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,…
$ group                              <chr> "Vector geometry", "General", "Road networks", "Road networks", "Road…
$ has_known_issues                   <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,…
$ help_url                           <chr> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, N…
$ name                               <chr> "Tessellate", "Average linestrings", "Collapse dual carriageways", "R…
$ requires_matching_crs              <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,…
$ short_description                  <chr> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, N…
$ tags                               <list> <"3d", "triangle">, [], [], [], [], [], <"ogr", "gdal", "gdaldem">, …
$ provider_can_be_activated          <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRU…
$ default_raster_file_extension      <chr> "tif", "tif", "tif", "tif", "tif", "tif", "tif", "tif", "tif", "tif",…
$ default_vector_file_extension      <chr> "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg…
$ provider_is_active                 <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRU…
$ provider_long_name                 <chr> "QGIS (3D)", "Cartography tools", "Cartography tools", "Cartography t…
$ provider_name                      <chr> "QGIS (3D)", "Cartography tools", "Cartography tools", "Cartography t…
$ supported_output_raster_extensions <list> <"tif", "gen", "bag", "bmp", "bt", "byn", "bil", "ers", "fits", "gpk…
$ supported_output_table_extensions  <list> <"gpkg", "shp", "000", "csv", "dgn", "dxf", "fgb", "gdb", "geojson",…
$ supported_output_vector_extensions <list> <"gpkg", "shp", "000", "csv", "dgn", "dxf", "fgb", "gdb", "geojson",…
$ supports_non_file_based_output     <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE…
$ provider_version                   <chr> NA, "1.2.1", "1.2.1", "1.2.1", "1.2.1", "1.2.1", NA, NA, NA, NA, NA, …
$ provider_warning                   <chr> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, N…

> 
> qgis_providers()
# A tibble: 9 × 2
  provider         provider_title                        
  <chr>            <chr>                                 
1 3d               QGIS (3D)                             
2 cartographytools Cartography tools                     
3 gdal             GDAL                                  
4 grass7           GRASS                                 
5 native           QGIS (native c++)                     
6 otb              OTB                                   
7 qgis             QGIS                                  
8 qneat3           QNEAT3 - Qgis Network Analysis Toolbox
9 visibility       Visibility analysis        
```

#### New behaviour

```r
> dplyr::glimpse(qgis_algorithms())
Rows: 785
Columns: 24
$ provider                           <chr> "3d", "cartographytools", "cartographytools", "cartographytools", "ca…
$ provider_title                     <chr> "QGIS (3D)", "Cartography tools", "Cartography tools", "Cartography t…
$ algorithm                          <chr> "3d:tessellate", "cartographytools:averagelines", "cartographytools:c…
$ algorithm_id                       <chr> "tessellate", "averagelines", "collapsedualcarriageway", "removecross…
$ algorithm_title                    <chr> "Tessellate", "Average linestrings", "Collapse dual carriageways", "R…
$ provider_can_be_activated          <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRU…
$ provider_is_active                 <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRU…
$ provider_long_name                 <chr> "QGIS (3D)", "Cartography tools", "Cartography tools", "Cartography t…
$ provider_version                   <chr> NA, "1.2.1", "1.2.1", "1.2.1", "1.2.1", "1.2.1", NA, NA, NA, NA, NA, …
$ provider_warning                   <chr> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, N…
$ can_cancel                         <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRU…
$ deprecated                         <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,…
$ group                              <chr> "Vector geometry", "General", "Road networks", "Road networks", "Road…
$ has_known_issues                   <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,…
$ help_url                           <chr> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, N…
$ requires_matching_crs              <lgl> FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,…
$ short_description                  <chr> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, N…
$ tags                               <list> <"3d", "triangle">, [], [], [], [], [], <"ogr", "gdal", "gdaldem">, …
$ default_raster_file_extension      <chr> "tif", "tif", "tif", "tif", "tif", "tif", "tif", "tif", "tif", "tif",…
$ default_vector_file_extension      <chr> "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg", "gpkg…
$ supported_output_raster_extensions <list> <"tif", "gen", "bag", "bmp", "bt", "byn", "bil", "ers", "fits", "gpk…
$ supported_output_table_extensions  <list> <"gpkg", "shp", "000", "csv", "dgn", "dxf", "fgb", "gdb", "geojson",…
$ supported_output_vector_extensions <list> <"gpkg", "shp", "000", "csv", "dgn", "dxf", "fgb", "gdb", "geojson",…
$ supports_non_file_based_output     <lgl> TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE…
>
> qgis_providers()
# A tibble: 9 × 3
  provider         provider_title                         algorithm_count
  <chr>            <chr>                                            <int>
1 cartographytools Cartography tools                                    5
2 gdal             GDAL                                                56
3 grass7           GRASS                                              304
4 otb              OTB                                                109
5 qgis             QGIS                                                50
6 3d               QGIS (3D)                                            1
7 native           QGIS (native c++)                                  242
8 qneat3           QNEAT3 - Qgis Network Analysis Toolbox              14
9 visibility       Visibility analysis                                  4
```